### PR TITLE
ftests: Add recursive cgdelete functional test

### DIFF
--- a/ftests/002-cgdelete-recursive_delete.py
+++ b/ftests/002-cgdelete-recursive_delete.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python3
+#
+# Cgroup recursive cgdelete functionality test
+#
+# Copyright (c) 2020 Oracle and/or its affiliates.
+# Author: Tom Hromatka <tom.hromatka@oracle.com>
+#
+
+#
+# This library is free software; you can redistribute it and/or modify it
+# under the terms of version 2.1 of the GNU Lesser General Public License as
+# published by the Free Software Foundation.
+#
+# This library is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License
+# for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this library; if not, see <http://www.gnu.org/licenses>.
+#
+
+from cgroup import Cgroup
+import consts
+import ftests
+import os
+import sys
+
+CONTROLLER = 'cpuset'
+PARENT = '002cgdelete'
+CHILD = 'childcg'
+GRANDCHILD = 'grandchildcg'
+
+def prereqs(config):
+    # This test should run on both cgroup v1 and v2
+    return consts.TEST_PASSED, None
+
+def setup(config):
+    Cgroup.create(config, CONTROLLER, PARENT)
+    Cgroup.create(config, CONTROLLER, os.path.join(PARENT, CHILD))
+    Cgroup.create(config, CONTROLLER, os.path.join(PARENT, CHILD, GRANDCHILD))
+
+def test(config):
+    Cgroup.delete(config, CONTROLLER, PARENT, recursive=True)
+
+    return consts.TEST_PASSED, None
+
+def teardown(config):
+    pass
+
+def main(config):
+    [result, cause] = prereqs(config)
+    if result != consts.TEST_PASSED:
+        return [result, cause]
+
+    setup(config)
+    [result, cause] = test(config)
+    teardown(config)
+
+    return [result, cause]
+
+if __name__ == '__main__':
+    config = ftests.parse_args()
+    # this test was invoked directly.  run only it
+    config.args.num = int(os.path.basename(__file__).split('-')[0])
+    sys.exit(ftests.main(config))

--- a/ftests/Makefile.am
+++ b/ftests/Makefile.am
@@ -19,7 +19,8 @@
 # along with this library; if not, see <http://www.gnu.org/licenses>.
 #
 
-TESTS = 001-cgget-basic_cgget.py
+TESTS = 001-cgget-basic_cgget.py \
+	002-cgdelete-recursive_delete.py
 
 EXTRA_DIST = *.py README.md default.conf
 


### PR DESCRIPTION
Add a test that creates a cgroup hierarchy and then invokes
cgdelete on the parent cgroup with the recursive flag set.

-----------------------------------------------------------------
Test Results:
        Run Date:                     Oct 16 14:54:20
        Passed:                             2 test(s)
        Skipped:                            0 test(s)
        Failed:                             0 test(s)
-----------------------------------------------------------------
Timing Results:
        Test                               Time (sec)
        ---------------------------------------------------------
        setup                                   15.11
        001-cgget-basic_cgget.py                 0.53
        002-cgdelete-recursive_delete.py         0.26
        teardown                                 0.00
        ---------------------------------------------------------
        Total Run Time                          15.90

Signed-off-by: Tom Hromatka <tom.hromatka@oracle.com>