### PR TITLE
ftests: Invoke ftests.sh in Makefile.am

### DIFF
--- a/ftests/Makefile.am
+++ b/ftests/Makefile.am
@@ -1,7 +1,7 @@
 #
 # libcgroup functional tests Makefile.am
 #
-# Copyright (c) 2019 Oracle and/or its affiliates.  All rights reserved.
+# Copyright (c) 2019-2020 Oracle and/or its affiliates.
 # Author: Tom Hromatka <tom.hromatka@oracle.com>
 #
 
@@ -19,11 +19,9 @@
 # along with this library; if not, see <http://www.gnu.org/licenses>.
 #
 
-TESTS = 001-cgget-basic_cgget_v1.py \
-	002-cgdelete-recursive_delete.py \
-	003-cgget-basic_cgget_v2.py
+TESTS = ftests.sh
 
-EXTRA_DIST = *.py README.md default.conf
+EXTRA_DIST = *.py README.md default.conf ftests.sh
 
 clean-local: clean-local-check
 .PHONY: clean-local-check

--- a/ftests/ftests.py
+++ b/ftests/ftests.py
@@ -304,10 +304,10 @@ def main(config):
 
     if failed_cnt > 0:
         return failed_cnt
-    if skipped_cnt > 0:
-        return AUTOMAKE_SKIPPED
     if passed_cnt > 0:
         return AUTOMAKE_PASSED
+    if skipped_cnt > 0:
+        return AUTOMAKE_SKIPPED
 
     return AUTOMAKE_HARD_ERROR
 

--- a/ftests/ftests.sh
+++ b/ftests/ftests.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+./ftests.py -l 10 -L ftests.log


### PR DESCRIPTION
Invoke a wrapper script, ftests.sh, in the TESTS target
within Makefile.am.  This provides two advantages:
1. When new tests are added, Makefile.am does not need
   to be updated
2. This adds verbose logging to the continuous integration
   suite

Signed-off-by: Tom Hromatka <tom.hromatka@oracle.com>