### PR TITLE
Add support to run the functional tests outside of a container

### DIFF
--- a/ftests/002-cgdelete-recursive_delete.py
+++ b/ftests/002-cgdelete-recursive_delete.py
@@ -2,7 +2,7 @@
 #
 # Cgroup recursive cgdelete functionality test
 #
-# Copyright (c) 2020 Oracle and/or its affiliates.
+# Copyright (c) 2020-2021 Oracle and/or its affiliates.
 # Author: Tom Hromatka <tom.hromatka@oracle.com>
 #
 
@@ -49,7 +49,7 @@ def setup(config):
         # Moving a process from a child cgroup to its parent isn't (easily)
         # supported in cgroup v2 because of cgroup v2's restriction that
         # processes only be located in leaf cgroups
-        Process.create_process_in_cgroup(config, CONTROLLER,
+        config.process.create_process_in_cgroup(config, CONTROLLER,
                                          os.path.join(PARENT, CHILD, GRANDCHILD))
 
 def test(config):

--- a/ftests/004-cgsnapshot-basic_snapshot_v1.py
+++ b/ftests/004-cgsnapshot-basic_snapshot_v1.py
@@ -2,7 +2,7 @@
 #
 # Basic cgsnapshot functionality test
 #
-# Copyright (c) 2020 Oracle and/or its affiliates.
+# Copyright (c) 2020-2021 Oracle and/or its affiliates.
 # Author: Tom Hromatka <tom.hromatka@oracle.com>
 #
 
@@ -61,6 +61,12 @@ def prereqs(config):
     if CgroupVersion.get_version('memory') != CgroupVersion.CGROUP_V1:
         result = consts.TEST_SKIPPED
         cause = "This test requires the cgroup v1 memory controller"
+        return result, cause
+
+    if not config.args.container:
+        result = consts.TEST_SKIPPED
+        cause = "This test must be run within a container"
+        return result, cause
 
     return result, cause
 

--- a/ftests/Makefile.am
+++ b/ftests/Makefile.am
@@ -1,7 +1,7 @@
 #
 # libcgroup functional tests Makefile.am
 #
-# Copyright (c) 2019-2020 Oracle and/or its affiliates.
+# Copyright (c) 2019-2021 Oracle and/or its affiliates.
 # Author: Tom Hromatka <tom.hromatka@oracle.com>
 #
 
@@ -19,9 +19,9 @@
 # along with this library; if not, see <http://www.gnu.org/licenses>.
 #
 
-TESTS = ftests.sh
+TESTS = ftests.sh ftests-nocontainer.sh
 
-EXTRA_DIST = *.py README.md default.conf ftests.sh
+EXTRA_DIST = *.py README.md default.conf ftests.sh ftests-nocontainer.sh
 
 clean-local: clean-local-check
 .PHONY: clean-local-check

--- a/ftests/cgroup.py
+++ b/ftests/cgroup.py
@@ -90,6 +90,9 @@ class Cgroup(object):
             controller_list = [controller_list]
 
         cmd = list()
+
+        if not config.args.container:
+            cmd.append('sudo')
         cmd.append(Cgroup.build_cmd_path('cgcreate'))
 
         controllers_and_path = '{}:{}'.format(
@@ -109,6 +112,9 @@ class Cgroup(object):
             controller_list = [controller_list]
 
         cmd = list()
+
+        if not config.args.container:
+            cmd.append('sudo')
         cmd.append(Cgroup.build_cmd_path('cgdelete'))
 
         if recursive:
@@ -128,6 +134,9 @@ class Cgroup(object):
     @staticmethod
     def set(config, cgname, setting, value):
         cmd = list()
+
+        if not config.args.container:
+            cmd.append('sudo')
         cmd.append(Cgroup.build_cmd_path('cgset'))
 
         if isinstance(setting, str) and isinstance(value, str):
@@ -226,6 +235,9 @@ class Cgroup(object):
     def classify(config, controller, cgname, pid_list, sticky=False,
                  cancel_sticky=False):
         cmd = list()
+
+        if not config.args.container:
+            cmd.append('sudo')
         cmd.append(Cgroup.build_cmd_path('cgclassify'))
         cmd.append('-g')
         cmd.append('{}:{}'.format(controller, cgname))

--- a/ftests/cgroup.py
+++ b/ftests/cgroup.py
@@ -336,11 +336,11 @@ class Cgroup(object):
         if controller is not None:
             cmd.append(controller)
 
+        # ensure the deny list file exists
         if config.args.container:
-            # if we're running in a container, it's unlikely that libcgroup
-            # was installed and thus /etc/cgsnapshot_blacklist.conf likely
-            # doesn't exist.  Let's make it
             config.container.run(['sudo', 'touch', '/etc/cgsnapshot_blacklist.conf'])
+        else:
+            Run.run(['sudo', 'touch', '/etc/cgsnapshot_blacklist.conf'])
 
         if config.args.container:
             res = config.container.run(cmd)

--- a/ftests/config.py
+++ b/ftests/config.py
@@ -22,6 +22,8 @@
 import consts
 from container import Container
 import os
+from process import Process
+import utils
 
 class Config(object):
     def __init__(self, args, container=None):
@@ -36,6 +38,8 @@ class Config(object):
                     stop_timeout=args.timeout, arch=None,
                     distro=args.distro, release=args.release)
 
+        self.process = Process()
+
         self.ftest_dir = os.path.dirname(os.path.abspath(__file__))
         self.libcg_dir = os.path.dirname(self.ftest_dir)
 
@@ -44,12 +48,12 @@ class Config(object):
         self.verbose = False
 
     def __str__(self):
-        out_str = "Configuration"
+        out_str = "Configuration\n"
         if self.args.container:
-            out_str += "\n\tcontainer = {}".format(self.container)
+            out_str += utils.indent(str(self.container), 4)
+        out_str += utils.indent(str(self.process), 4)
 
         return out_str
-
 
 class ConfigError(Exception):
     def __init__(self, message):

--- a/ftests/config.py
+++ b/ftests/config.py
@@ -1,7 +1,7 @@
 #
 # Config class for the libcgroup functional tests
 #
-# Copyright (c) 2019 Oracle and/or its affiliates.  All rights reserved.
+# Copyright (c) 2019-2021 Oracle and/or its affiliates.
 # Author: Tom Hromatka <tom.hromatka@oracle.com>
 #
 
@@ -27,13 +27,14 @@ class Config(object):
     def __init__(self, args, container=None):
         self.args = args
 
-        if container:
-            self.container = container
-        else:
-            # Use the default container settings
-            self.container = Container(name=consts.DEFAULT_CONTAINER_NAME,
-                stop_timeout=args.timeout, arch=None,
-                distro=args.distro, release=args.release)
+        if self.args.container:
+            if container:
+                self.container = container
+            else:
+                # Use the default container settings
+                self.container = Container(name=consts.DEFAULT_CONTAINER_NAME,
+                    stop_timeout=args.timeout, arch=None,
+                    distro=args.distro, release=args.release)
 
         self.ftest_dir = os.path.dirname(os.path.abspath(__file__))
         self.libcg_dir = os.path.dirname(self.ftest_dir)
@@ -44,7 +45,8 @@ class Config(object):
 
     def __str__(self):
         out_str = "Configuration"
-        out_str += "\n\tcontainer = {}".format(self.container)
+        if self.args.container:
+            out_str += "\n\tcontainer = {}".format(self.container)
 
         return out_str
 

--- a/ftests/container.py
+++ b/ftests/container.py
@@ -1,7 +1,7 @@
 #
 # Container class for the libcgroup functional tests
 #
-# Copyright (c) 2019 Oracle and/or its affiliates.  All rights reserved.
+# Copyright (c) 2019-2021 Oracle and/or its affiliates.
 # Author: Tom Hromatka <tom.hromatka@oracle.com>
 #
 
@@ -58,11 +58,11 @@ class Container(object):
 
 
     def __str__(self):
-        out_str = "{}".format(self.name)
+        out_str = "Container {}".format(self.name)
         out_str += "\n\tdistro = {}".format(self.distro)
         out_str += "\n\trelease = {}".format(self.release)
         out_str += "\n\tarch = {}".format(self.arch)
-        out_str += "\n\tstop_timeout = {}".format(self.stop_timeout)
+        out_str += "\n\tstop_timeout = {}\n".format(self.stop_timeout)
 
         return out_str
 

--- a/ftests/ftests-nocontainer.sh
+++ b/ftests/ftests-nocontainer.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+./ftests.py -l 10 -L ftests-nocontainer.log --no-container

--- a/ftests/ftests.py
+++ b/ftests/ftests.py
@@ -141,6 +141,7 @@ def update_host_subgid():
 
 def setup(config, do_teardown=True, record_time=False):
     global setup_time
+
     start_time = time.time()
     if do_teardown:
         # belt and suspenders here.  In case a previous run wasn't properly
@@ -289,7 +290,7 @@ def teardown(config, record_time=False):
     global teardown_time
     start_time = time.time()
 
-    Process.join_children()
+    config.process.join_children(config)
 
     if config.args.container:
         try:

--- a/ftests/process.py
+++ b/ftests/process.py
@@ -22,26 +22,40 @@
 from cgroup import Cgroup
 import multiprocessing as mp
 from run import Run
+from run import RunError
 import time
 
-children = list()
-
 class Process(object):
+    def __init__(self):
+        self.children = list()
+        self.children_pids = list()
+
+    def __str__(self):
+        out_str = "Process Class\n"
+        out_str += "\tchildren = {}\n".format(self.children)
+        out_str += "\tchildren_pids = {}\n".format(self.children_pids)
+
+        return out_str
+
     @staticmethod
     def __infinite_loop(config, sleep_time=1):
-        cmd = ['nohup', 'perl', '-e', '\'while(1){{sleep({})}};\''.format(sleep_time), '&']
+        cmd = ['/usr/bin/perl', '-e', '\'while(1){{sleep({})}};\''.format(sleep_time)]
 
-        if config.args.container:
-            config.container.run(cmd, shell_bool=True)
-        else:
-            Run.run(cmd, shell_bool=True)
+        try:
+            if config.args.container:
+                config.container.run(cmd, shell_bool=True)
+            else:
+                Run.run(cmd, shell_bool=True)
+        except RunError as re:
+            # when the process is killed, a RunError will be thrown.  let's
+            # catch and suppress it
+            pass
 
-    @staticmethod
-    def create_process(config):
+    def create_process(self, config):
         # To allow for multiple processes to be created, each new process
         # sleeps for a different amount of time.  This lets us uniquely find
         # each process later in this function
-        sleep_time = len(children) + 1
+        sleep_time = len(self.children) + 1
 
         p = mp.Process(target=Process.__infinite_loop,
                        args=(config, sleep_time, ))
@@ -56,22 +70,38 @@ class Process(object):
         if config.args.container:
             pid = config.container.run(cmd, shell_bool=True)
         else:
-            pid = Run.run(cmd, shell_bool=True)
+            pid = Run.run(cmd, shell_bool=True).decode('ascii')
+
+            for _pid in pid.splitlines():
+                self.children_pids.append(_pid)
+
+            if pid.find('\n') >= 0:
+                # The second pid in the list contains the actual perl process
+                pid = pid.splitlines()[1]
 
         if pid == "" or int(pid) <= 0:
             raise ValueException('Failed to get the pid of the child process: {}'.format(pid))
 
-        children.append(p)
+        self.children.append(p)
         return pid
 
     # Create a simple process in the requested cgroup
-    @staticmethod
-    def create_process_in_cgroup(config, controller, cgname):
-        child_pid = Process.create_process(config)
+    def create_process_in_cgroup(self, config, controller, cgname):
+        child_pid = self.create_process(config)
         Cgroup.classify(config, controller, cgname, child_pid)
 
     # The caller will block until all children are stopped.
-    @staticmethod
-    def join_children():
-        for child in children:
+    def join_children(self, config):
+        for child in self.children:
              child.join(1)
+
+        for child in self.children_pids:
+            try:
+                if config.args.container:
+                    config.container.run(['kill', child])
+                else:
+                    Run.run(['kill', child])
+            except:
+                # ignore any errors during the kill command.  this is belt
+                # and suspenders code
+                pass

--- a/ftests/process.py
+++ b/ftests/process.py
@@ -1,7 +1,7 @@
 #
 # Cgroup class for the libcgroup functional tests
 #
-# Copyright (c) 2020 Oracle and/or its affiliates.
+# Copyright (c) 2020-2021 Oracle and/or its affiliates.
 # Author: Tom Hromatka <tom.hromatka@oracle.com>
 #
 
@@ -28,16 +28,16 @@ children = list()
 
 class Process(object):
     @staticmethod
-    def __infinite_loop(config, sleep_time=1, in_container=True):
+    def __infinite_loop(config, sleep_time=1):
         cmd = ['nohup', 'perl', '-e', '\'while(1){{sleep({})}};\''.format(sleep_time), '&']
 
-        if in_container:
+        if config.args.container:
             config.container.run(cmd, shell_bool=True)
         else:
             Run.run(cmd, shell_bool=True)
 
     @staticmethod
-    def create_process(config, in_container=True):
+    def create_process(config):
         # To allow for multiple processes to be created, each new process
         # sleeps for a different amount of time.  This lets us uniquely find
         # each process later in this function
@@ -53,7 +53,7 @@ class Process(object):
 
         # get the PID of the newly spawned infinite loop
         cmd = 'ps x | grep perl | grep "sleep({})" | awk \'{{print $1}}\''.format(sleep_time)
-        if in_container:
+        if config.args.container:
             pid = config.container.run(cmd, shell_bool=True)
         else:
             pid = Run.run(cmd, shell_bool=True)
@@ -66,10 +66,9 @@ class Process(object):
 
     # Create a simple process in the requested cgroup
     @staticmethod
-    def create_process_in_cgroup(config, controller, cgname, in_container=True):
-        child_pid = Process.create_process(config, in_container=in_container)
-        Cgroup.classify(config, controller, cgname, child_pid,
-                        in_container=in_container)
+    def create_process_in_cgroup(config, controller, cgname):
+        child_pid = Process.create_process(config)
+        Cgroup.classify(config, controller, cgname, child_pid)
 
     # The caller will block until all children are stopped.
     @staticmethod


### PR DESCRIPTION
This patchset adds logic to enable the functional tests
to be run outside of a container.  (Note that they still
run inside of an LXC container.)

make check (which is invoked by Github Actions) has been
updated to run the functional tests both inside and
outside of a container.

These changes are in preparation for adding tests for
cgrulesengd.  It currently does not run within a
container.

Code is available here:
https://github.com/drakenclimber/libcgroup/tree/issues/nocontainer

Tests are available here:
https://github.com/drakenclimber/libcgroup-tests/tree/issues/nocontainer

Code coverage remained the same at 31.5%:
https://coveralls.io/builds/36846105

Test results are available here:
https://github.com/drakenclimber/libcgroup/runs/1826371745