### PR TITLE
Add cgrules functional tests

### DIFF
--- a/ftests/006-cgrules-basic_cgrules_v1.py
+++ b/ftests/006-cgrules-basic_cgrules_v1.py
@@ -1,0 +1,101 @@
+#!/usr/bin/env python3
+#
+# Basic cgrules functionality test
+#
+# Copyright (c) 2021 Oracle and/or its affiliates.
+# Author: Tom Hromatka <tom.hromatka@oracle.com>
+#
+
+#
+# This library is free software; you can redistribute it and/or modify it
+# under the terms of version 2.1 of the GNU Lesser General Public License as
+# published by the Free Software Foundation.
+#
+# This library is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License
+# for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this library; if not, see <http://www.gnu.org/licenses>.
+#
+
+from cgroup import Cgroup, CgroupVersion
+import consts
+import ftests
+import os
+from process import Process
+import sys
+
+CONTROLLER='cpu'
+PARENT_CGNAME='006cgrules'
+CHILD_CGNAME='childcg'
+
+# move all perl processes to the 006cgrules/childcg cgroup in the
+# cpu controller
+CGRULE="*:/usr/bin/perl cpu {}".format(os.path.join(PARENT_CGNAME, CHILD_CGNAME))
+
+cg = Cgroup(os.path.join(PARENT_CGNAME, CHILD_CGNAME))
+
+def prereqs(config):
+    result = consts.TEST_PASSED
+    cause = None
+
+    if config.args.container:
+        result = consts.TEST_SKIPPED
+        cause = "This test cannot be run within a container"
+        return result, cause
+
+    if CgroupVersion.get_version('cpu') != CgroupVersion.CGROUP_V1:
+        result = consts.TEST_SKIPPED
+        cause = "This test requires the cgroup v1 cpu controller"
+        return result, cause
+
+    return result, cause
+
+def setup(config):
+    Cgroup.create(config, CONTROLLER, PARENT_CGNAME)
+    Cgroup.create(config, CONTROLLER, os.path.join(PARENT_CGNAME, CHILD_CGNAME))
+
+    Cgroup.set_cgrules_conf(config, CGRULE, append=False)
+    cg.start_cgrules(config)
+
+def test(config):
+    result = consts.TEST_PASSED
+    cause = None
+
+    pid = config.process.create_process(config)
+    proc_cgroup = Process.get_cgroup(config, pid, CONTROLLER)
+
+    # proc/{pid}/cgroup alsways prepends a '/' to the cgroup path
+    if proc_cgroup != os.path.join('/', PARENT_CGNAME, CHILD_CGNAME):
+        result = consts.TEST_FAILED
+        cause = "PID {} was expected to be in cgroup {} but is in cgroup {}".format(
+                    pid, os.path.join('/', PARENT_CGNAME, CHILD_CGNAME), proc_cgroup)
+
+    return result, cause
+
+def teardown(config):
+    # destroy the child processes
+    config.process.join_children(config)
+    cg.join_children(config)
+    Cgroup.delete(config, CONTROLLER, PARENT_CGNAME, recursive=True)
+
+def main(config):
+    [result, cause] = prereqs(config)
+    if result != consts.TEST_PASSED:
+        return [result, cause]
+
+    try:
+        setup(config)
+        [result, cause] = test(config)
+    finally:
+        teardown(config)
+
+    return [result, cause]
+
+if __name__ == '__main__':
+    config = ftests.parse_args()
+    # this test was invoked directly.  run only it
+    config.args.num = int(os.path.basename(__file__).split('-')[0])
+    sys.exit(ftests.main(config))

--- a/ftests/007-cgrules-basic_cgrules_v2.py
+++ b/ftests/007-cgrules-basic_cgrules_v2.py
@@ -1,0 +1,99 @@
+#!/usr/bin/env python3
+#
+# Basic cgrules functionality test
+#
+# Copyright (c) 2021 Oracle and/or its affiliates.
+# Author: Tom Hromatka <tom.hromatka@oracle.com>
+#
+
+#
+# This library is free software; you can redistribute it and/or modify it
+# under the terms of version 2.1 of the GNU Lesser General Public License as
+# published by the Free Software Foundation.
+#
+# This library is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License
+# for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this library; if not, see <http://www.gnu.org/licenses>.
+#
+
+from cgroup import Cgroup, CgroupVersion
+import consts
+import ftests
+import os
+from process import Process
+import sys
+
+CONTROLLER='cpuset'
+CGNAME='007cgrules'
+
+# move all perl processes to the 007cgrules cgroup in the
+# cpuset controller
+CGRULE="*:/usr/bin/perl cpuset {}".format(CGNAME)
+
+cg = Cgroup(CGNAME)
+
+def prereqs(config):
+    result = consts.TEST_PASSED
+    cause = None
+
+    if config.args.container:
+        result = consts.TEST_SKIPPED
+        cause = "This test cannot be run within a container"
+        return result, cause
+
+    if CgroupVersion.get_version('cpuset') != CgroupVersion.CGROUP_V2:
+        result = consts.TEST_SKIPPED
+        cause = "This test requires the cgroup v2 cpuset controller"
+        return result, cause
+
+    return result, cause
+
+def setup(config):
+    Cgroup.create(config, CONTROLLER, CGNAME)
+
+    Cgroup.set_cgrules_conf(config, CGRULE, append=False)
+    cg.start_cgrules(config)
+
+def test(config):
+    result = consts.TEST_PASSED
+    cause = None
+
+    pid = config.process.create_process(config)
+    proc_cgroup = Process.get_cgroup(config, pid, CONTROLLER)
+
+    # proc/{pid}/cgroup alsways prepends a '/' to the cgroup path
+    if proc_cgroup != os.path.join('/', CGNAME):
+        result = consts.TEST_FAILED
+        cause = "PID {} was expected to be in cgroup {} but is in cgroup {}".format(
+                    pid, os.path.join('/', CGNAME), proc_cgroup)
+
+    return result, cause
+
+def teardown(config):
+    # destroy the child processes
+    config.process.join_children(config)
+    cg.join_children(config)
+    Cgroup.delete(config, CONTROLLER, CGNAME, recursive=False)
+
+def main(config):
+    [result, cause] = prereqs(config)
+    if result != consts.TEST_PASSED:
+        return [result, cause]
+
+    try:
+        setup(config)
+        [result, cause] = test(config)
+    finally:
+        teardown(config)
+
+    return [result, cause]
+
+if __name__ == '__main__':
+    config = ftests.parse_args()
+    # this test was invoked directly.  run only it
+    config.args.num = int(os.path.basename(__file__).split('-')[0])
+    sys.exit(ftests.main(config))

--- a/ftests/cgroup.py
+++ b/ftests/cgroup.py
@@ -51,7 +51,7 @@ class CgroupVersion(Enum):
                             if ctrl == controller:
                                 return CgroupVersion.CGROUP_V2
 
-        return CgroupVersion.CGROUP_UNK
+        raise IndexError("Unknown version for controller {}".format(controller))
 
 class Cgroup(object):
     # This class is analogous to libcgroup's struct cgroup

--- a/ftests/consts.py
+++ b/ftests/consts.py
@@ -1,7 +1,7 @@
 #
 # Constants for the libcgroup functional tests
 #
-# Copyright (c) 2019 Oracle and/or its affiliates.  All rights reserved.
+# Copyright (c) 2019-2021 Oracle and/or its affiliates.
 # Author: Tom Hromatka <tom.hromatka@oracle.com>
 #
 
@@ -43,3 +43,5 @@ TESTS_RUN_ALL_SUITES = "allsuites"
 TEST_PASSED = "passed"
 TEST_FAILED = "failed"
 TEST_SKIPPED = "skipped"
+
+CGRULES_FILE = "/etc/cgrules.conf"

--- a/ftests/ftests.py
+++ b/ftests/ftests.py
@@ -234,7 +234,7 @@ def run_tests(config):
                         elif ret == consts.TEST_SKIPPED:
                             skipped_tests.append([filename, run_time, failure_cause])
                         else:
-                            raise ValueException('Unexpected ret: {}'.format(ret))
+                            raise ValueError('Unexpected ret: {}'.format(ret))
 
     passed_cnt = len(passed_tests)
     failed_cnt = len(failed_tests)

--- a/ftests/process.py
+++ b/ftests/process.py
@@ -81,7 +81,7 @@ class Process(object):
                 pid = pid.splitlines()[1]
 
         if pid == "" or int(pid) <= 0:
-            raise ValueException('Failed to get the pid of the child process: {}'.format(pid))
+            raise ValueError('Failed to get the pid of the child process: {}'.format(pid))
 
         self.children.append(p)
         return pid


### PR DESCRIPTION
This patchset adds two cgrulesengd functional tests and
the underlying framework required to run them.  Note that
this branch is built upon the recent patchset I sent out
to add support for running the functional tests outside of
a container [1].

Because of the netlink socket used by cgrules, these tests
must be run outside of a container and may be destructive to
the host system.  Thus, it's highly recommended to run these
tests in a throwaway virtual machine.

Test code is available here:
https://github.com/drakenclimber/libcgroup/tree/issues/cgrules4

Code coverage increased 11.8% and is now at 43.3%:
https://coveralls.io/builds/36957334

Automated test results are available here:
https://github.com/drakenclimber/libcgroup/runs/1857035811

[1] https://sourceforge.net/p/libcg/mailman/message/37212244/