### PR TITLE
Add extensive cgget functional tests

### DIFF
--- a/ftests/008-cgget-multiple_r_flags.py
+++ b/ftests/008-cgget-multiple_r_flags.py
@@ -1,0 +1,93 @@
+#!/usr/bin/env python3
+#
+# Advanced cgget functionality test - multiple '-r' flags
+#
+# Copyright (c) 2021 Oracle and/or its affiliates.
+# Author: Tom Hromatka <tom.hromatka@oracle.com>
+#
+
+#
+# This library is free software; you can redistribute it and/or modify it
+# under the terms of version 2.1 of the GNU Lesser General Public License as
+# published by the Free Software Foundation.
+#
+# This library is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License
+# for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this library; if not, see <http://www.gnu.org/licenses>.
+#
+
+from cgroup import Cgroup, CgroupVersion
+import consts
+import ftests
+import os
+import sys
+
+CONTROLLER = 'memory'
+CGNAME = '008cgget'
+
+SETTING1 = 'memory.limit_in_bytes'
+VALUE1 = '1048576'
+
+SETTING2='memory.soft_limit_in_bytes'
+VALUE2 = '1024000'
+
+def prereqs(config):
+    result = consts.TEST_PASSED
+    cause = None
+
+    return result, cause
+
+def setup(config):
+    Cgroup.create(config, CONTROLLER, CGNAME)
+    Cgroup.set(config, CGNAME, SETTING1, VALUE1)
+    Cgroup.set(config, CGNAME, SETTING2, VALUE2)
+
+def test(config):
+    result = consts.TEST_PASSED
+    cause = None
+
+    out = Cgroup.get(config, controller=None, cgname=CGNAME,
+                     setting=[SETTING1, SETTING2])
+
+    if out.splitlines()[0] != "{}:".format(CGNAME):
+        result = consts.TEST_FAILED
+        cause = "cgget expected the cgroup name {} in the first line.\n" \
+                "Instead it received {}".format(CGNAME, out.splitlines()[0])
+
+    if out.splitlines()[1] != "{}: {}".format(SETTING1, VALUE1):
+        result = consts.TEST_FAILED
+        cause = "cgget expected the following:\n\t" \
+                "{}: {}\nbut received:\n\t{}".format(
+                SETTING1, VALUE1, out.splitlines()[1])
+
+    if out.splitlines()[2] != "{}: {}".format(SETTING2, VALUE2):
+        result = consts.TEST_FAILED
+        cause = "cgget expected the following:\n\t" \
+                "{}: {}\nbut received:\n\t{}".format(
+                SETTING2, VALUE2, out.splitlines()[2])
+
+    return result, cause
+
+def teardown(config):
+    Cgroup.delete(config, CONTROLLER, CGNAME)
+
+def main(config):
+    [result, cause] = prereqs(config)
+    if result != consts.TEST_PASSED:
+        return [result, cause]
+
+    setup(config)
+    [result, cause] = test(config)
+    teardown(config)
+
+    return [result, cause]
+
+if __name__ == '__main__':
+    config = ftests.parse_args()
+    # this test was invoked directly.  run only it
+    config.args.num = int(os.path.basename(__file__).split('-')[0])
+    sys.exit(ftests.main(config))

--- a/ftests/009-cgget-g_flag_controller_only.py
+++ b/ftests/009-cgget-g_flag_controller_only.py
@@ -1,0 +1,85 @@
+#!/usr/bin/env python3
+#
+# Advanced cgget functionality test - '-g' <controller>
+#
+# Copyright (c) 2021 Oracle and/or its affiliates.
+# Author: Tom Hromatka <tom.hromatka@oracle.com>
+#
+
+#
+# This library is free software; you can redistribute it and/or modify it
+# under the terms of version 2.1 of the GNU Lesser General Public License as
+# published by the Free Software Foundation.
+#
+# This library is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License
+# for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this library; if not, see <http://www.gnu.org/licenses>.
+#
+
+from cgroup import Cgroup, CgroupVersion
+import consts
+import ftests
+import os
+import sys
+
+CONTROLLER = 'cpu'
+CGNAME = '009cgget'
+
+EXPECTED_OUT = '''009cgget:
+cpu.cfs_period_us: 100000
+cpu.stat: nr_periods 0
+        nr_throttled 0
+        throttled_time 0
+cpu.shares: 1024
+cpu.cfs_quota_us: -1
+cpu.uclamp.min: 0.00
+cpu.uclamp.max: max
+'''
+
+def prereqs(config):
+    result = consts.TEST_PASSED
+    cause = None
+
+    return result, cause
+
+def setup(config):
+    Cgroup.create(config, CONTROLLER, CGNAME)
+
+def test(config):
+    result = consts.TEST_PASSED
+    cause = None
+
+    out = Cgroup.get(config, controller=CONTROLLER, cgname=CGNAME)
+
+    for line_num, line in enumerate(out.splitlines()):
+        if line.strip() != EXPECTED_OUT.splitlines()[line_num].strip():
+            result = consts.TEST_FAILED
+            cause = "Expected line:\n\t{}\nbut received line:\n\t{}".format(
+                    EXPECTED_OUT.splitlines()[line_num].strip(), line.strip())
+            return result, cause
+
+    return result, cause
+
+def teardown(config):
+    Cgroup.delete(config, CONTROLLER, CGNAME)
+
+def main(config):
+    [result, cause] = prereqs(config)
+    if result != consts.TEST_PASSED:
+        return [result, cause]
+
+    setup(config)
+    [result, cause] = test(config)
+    teardown(config)
+
+    return [result, cause]
+
+if __name__ == '__main__':
+    config = ftests.parse_args()
+    # this test was invoked directly.  run only it
+    config.args.num = int(os.path.basename(__file__).split('-')[0])
+    sys.exit(ftests.main(config))

--- a/ftests/010-cgget-g_flag_controller_and_cgroup.py
+++ b/ftests/010-cgget-g_flag_controller_and_cgroup.py
@@ -1,0 +1,85 @@
+#!/usr/bin/env python3
+#
+# Advanced cgget functionality test - '-g' <controller>:<path>
+#
+# Copyright (c) 2021 Oracle and/or its affiliates.
+# Author: Tom Hromatka <tom.hromatka@oracle.com>
+#
+
+#
+# This library is free software; you can redistribute it and/or modify it
+# under the terms of version 2.1 of the GNU Lesser General Public License as
+# published by the Free Software Foundation.
+#
+# This library is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License
+# for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this library; if not, see <http://www.gnu.org/licenses>.
+#
+
+from cgroup import Cgroup, CgroupVersion
+import consts
+import ftests
+import os
+import sys
+
+CONTROLLER = 'cpu'
+CGNAME = '010cgget'
+
+EXPECTED_OUT = '''cpu.cfs_period_us: 100000
+cpu.stat: nr_periods 0
+        nr_throttled 0
+        throttled_time 0
+cpu.shares: 1024
+cpu.cfs_quota_us: -1
+cpu.uclamp.min: 0.00
+cpu.uclamp.max: max
+'''
+
+def prereqs(config):
+    result = consts.TEST_PASSED
+    cause = None
+
+    return result, cause
+
+def setup(config):
+    Cgroup.create(config, CONTROLLER, CGNAME)
+
+def test(config):
+    result = consts.TEST_PASSED
+    cause = None
+
+    out = Cgroup.get(config, controller="{}:{}".format(CONTROLLER, CGNAME),
+                     print_headers=False)
+
+    for line_num, line in enumerate(out.splitlines()):
+        if line.strip() != EXPECTED_OUT.splitlines()[line_num].strip():
+            result = consts.TEST_FAILED
+            cause = "Expected line:\n\t{}\nbut received line:\n\t{}".format(
+                    EXPECTED_OUT.splitlines()[line_num].strip(), line.strip())
+            return result, cause
+
+    return result, cause
+
+def teardown(config):
+    Cgroup.delete(config, CONTROLLER, CGNAME)
+
+def main(config):
+    [result, cause] = prereqs(config)
+    if result != consts.TEST_PASSED:
+        return [result, cause]
+
+    setup(config)
+    [result, cause] = test(config)
+    teardown(config)
+
+    return [result, cause]
+
+if __name__ == '__main__':
+    config = ftests.parse_args()
+    # this test was invoked directly.  run only it
+    config.args.num = int(os.path.basename(__file__).split('-')[0])
+    sys.exit(ftests.main(config))

--- a/ftests/011-cgget-r_flag_two_cgroups.py
+++ b/ftests/011-cgget-r_flag_two_cgroups.py
@@ -1,0 +1,90 @@
+#!/usr/bin/env python3
+#
+# Advanced cgget functionality test - '-r' <name> <cgroup1> <cgroup2>
+#
+# Copyright (c) 2021 Oracle and/or its affiliates.
+# Author: Tom Hromatka <tom.hromatka@oracle.com>
+#
+
+#
+# This library is free software; you can redistribute it and/or modify it
+# under the terms of version 2.1 of the GNU Lesser General Public License as
+# published by the Free Software Foundation.
+#
+# This library is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License
+# for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this library; if not, see <http://www.gnu.org/licenses>.
+#
+
+from cgroup import Cgroup, CgroupVersion
+import consts
+import ftests
+import os
+import sys
+
+CONTROLLER = 'memory'
+CGNAME1 = '011cgget1'
+CGNAME2 = '011cgget2'
+
+SETTING = 'memory.limit_in_bytes'
+VALUE = '2048000'
+
+EXPECTED_OUT = '''011cgget1:
+memory.limit_in_bytes: 2048000
+
+011cgget2:
+memory.limit_in_bytes: 2048000
+'''
+
+def prereqs(config):
+    result = consts.TEST_PASSED
+    cause = None
+
+    return result, cause
+
+def setup(config):
+    Cgroup.create(config, CONTROLLER, CGNAME1)
+    Cgroup.create(config, CONTROLLER, CGNAME2)
+    Cgroup.set(config, CGNAME1, SETTING, VALUE)
+    Cgroup.set(config, CGNAME2, SETTING, VALUE)
+
+def test(config):
+    result = consts.TEST_PASSED
+    cause = None
+
+    out = Cgroup.get(config, controller=None, cgname=[CGNAME1, CGNAME2],
+                     setting=SETTING)
+
+    for line_num, line in enumerate(out.splitlines()):
+        if line.strip() != EXPECTED_OUT.splitlines()[line_num].strip():
+            result = consts.TEST_FAILED
+            cause = "Expected line:\n\t{}\nbut received line:\n\t{}".format(
+                    EXPECTED_OUT.splitlines()[line_num].strip(), line.strip())
+            return result, cause
+
+    return result, cause
+
+def teardown(config):
+    Cgroup.delete(config, CONTROLLER, CGNAME1)
+    Cgroup.delete(config, CONTROLLER, CGNAME2)
+
+def main(config):
+    [result, cause] = prereqs(config)
+    if result != consts.TEST_PASSED:
+        return [result, cause]
+
+    setup(config)
+    [result, cause] = test(config)
+    teardown(config)
+
+    return [result, cause]
+
+if __name__ == '__main__':
+    config = ftests.parse_args()
+    # this test was invoked directly.  run only it
+    config.args.num = int(os.path.basename(__file__).split('-')[0])
+    sys.exit(ftests.main(config))

--- a/ftests/012-cgget-multiple_r_flags2.py
+++ b/ftests/012-cgget-multiple_r_flags2.py
@@ -1,0 +1,97 @@
+#!/usr/bin/env python3
+#
+# Advanced cgget functionality test - multiple '-r' flags and multiple cgroups
+#
+# Copyright (c) 2021 Oracle and/or its affiliates.
+# Author: Tom Hromatka <tom.hromatka@oracle.com>
+#
+
+#
+# This library is free software; you can redistribute it and/or modify it
+# under the terms of version 2.1 of the GNU Lesser General Public License as
+# published by the Free Software Foundation.
+#
+# This library is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License
+# for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this library; if not, see <http://www.gnu.org/licenses>.
+#
+
+from cgroup import Cgroup, CgroupVersion
+import consts
+import ftests
+import os
+import sys
+
+CONTROLLER = 'memory'
+CGNAME1 = '012cgget1'
+CGNAME2 = '012cgget2'
+
+SETTING1 = 'memory.limit_in_bytes'
+VALUE1 = '4194304'
+
+SETTING2 = 'memory.soft_limit_in_bytes'
+VALUE2 = '4096000'
+
+EXPECTED_OUT = '''{}:
+{}
+{}
+
+{}:
+{}
+{}
+'''.format(CGNAME1, VALUE1, VALUE2, CGNAME2, VALUE1, VALUE2)
+
+def prereqs(config):
+    result = consts.TEST_PASSED
+    cause = None
+
+    return result, cause
+
+def setup(config):
+    Cgroup.create(config, CONTROLLER, CGNAME1)
+    Cgroup.create(config, CONTROLLER, CGNAME2)
+    Cgroup.set(config, CGNAME1, SETTING1, VALUE1)
+    Cgroup.set(config, CGNAME1, SETTING2, VALUE2)
+    Cgroup.set(config, CGNAME2, SETTING1, VALUE1)
+    Cgroup.set(config, CGNAME2, SETTING2, VALUE2)
+
+def test(config):
+    result = consts.TEST_PASSED
+    cause = None
+
+    out = Cgroup.get(config, controller=None, cgname=[CGNAME1, CGNAME2],
+                     setting=[SETTING1, SETTING2], values_only=True)
+
+    for line_num, line in enumerate(out.splitlines()):
+        if line.strip() != EXPECTED_OUT.splitlines()[line_num].strip():
+            result = consts.TEST_FAILED
+            cause = "Expected line:\n\t{}\nbut received line:\n\t{}".format(
+                    EXPECTED_OUT.splitlines()[line_num].strip(), line.strip())
+            return result, cause
+
+    return result, cause
+
+def teardown(config):
+    Cgroup.delete(config, CONTROLLER, CGNAME1)
+    Cgroup.delete(config, CONTROLLER, CGNAME2)
+
+def main(config):
+    [result, cause] = prereqs(config)
+    if result != consts.TEST_PASSED:
+        return [result, cause]
+
+    setup(config)
+    [result, cause] = test(config)
+    teardown(config)
+
+    return [result, cause]
+
+if __name__ == '__main__':
+    config = ftests.parse_args()
+    # this test was invoked directly.  run only it
+    config.args.num = int(os.path.basename(__file__).split('-')[0])
+    sys.exit(ftests.main(config))

--- a/ftests/013-cgget-multiple_g_flags.py
+++ b/ftests/013-cgget-multiple_g_flags.py
@@ -1,0 +1,92 @@
+#!/usr/bin/env python3
+#
+# Advanced cgget functionality test - multiple '-g' flags
+#
+# Copyright (c) 2021 Oracle and/or its affiliates.
+# Author: Tom Hromatka <tom.hromatka@oracle.com>
+#
+
+#
+# This library is free software; you can redistribute it and/or modify it
+# under the terms of version 2.1 of the GNU Lesser General Public License as
+# published by the Free Software Foundation.
+#
+# This library is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License
+# for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this library; if not, see <http://www.gnu.org/licenses>.
+#
+
+from cgroup import Cgroup, CgroupVersion
+import consts
+import ftests
+import os
+import sys
+
+CONTROLLER1 = 'freezer'
+CONTROLLER2 = 'cpu'
+CGNAME = '013cgget'
+
+EXPECTED_OUT = '''013cgget:
+freezer.self_freezing: 0
+freezer.parent_freezing: 0
+freezer.state: THAWED
+cpu.cfs_period_us: 100000
+cpu.stat: nr_periods 0
+        nr_throttled 0
+        throttled_time 0
+cpu.shares: 1024
+cpu.cfs_quota_us: -1
+cpu.uclamp.min: 0.00
+cpu.uclamp.max: max
+'''
+
+def prereqs(config):
+    result = consts.TEST_PASSED
+    cause = None
+
+    return result, cause
+
+def setup(config):
+    Cgroup.create(config, CONTROLLER1, CGNAME)
+    Cgroup.create(config, CONTROLLER2, CGNAME)
+
+def test(config):
+    result = consts.TEST_PASSED
+    cause = None
+
+    out = Cgroup.get(config, controller=[CONTROLLER1, CONTROLLER2],
+                     cgname=CGNAME)
+
+    for line_num, line in enumerate(out.splitlines()):
+        if line.strip() != EXPECTED_OUT.splitlines()[line_num].strip():
+            result = consts.TEST_FAILED
+            cause = "Expected line:\n\t{}\nbut received line:\n\t{}".format(
+                    EXPECTED_OUT.splitlines()[line_num].strip(), line.strip())
+            return result, cause
+
+    return result, cause
+
+def teardown(config):
+    Cgroup.delete(config, CONTROLLER1, CGNAME)
+    Cgroup.delete(config, CONTROLLER2, CGNAME)
+
+def main(config):
+    [result, cause] = prereqs(config)
+    if result != consts.TEST_PASSED:
+        return [result, cause]
+
+    setup(config)
+    [result, cause] = test(config)
+    teardown(config)
+
+    return [result, cause]
+
+if __name__ == '__main__':
+    config = ftests.parse_args()
+    # this test was invoked directly.  run only it
+    config.args.num = int(os.path.basename(__file__).split('-')[0])
+    sys.exit(ftests.main(config))

--- a/ftests/015-cgget-multiline_r_flag.py
+++ b/ftests/015-cgget-multiline_r_flag.py
@@ -1,0 +1,86 @@
+#!/usr/bin/env python3
+#
+# Advanced cgget functionality test - get a multiline value via the '-r' flag
+#
+# Copyright (c) 2021 Oracle and/or its affiliates.
+# Author: Tom Hromatka <tom.hromatka@oracle.com>
+#
+
+#
+# This library is free software; you can redistribute it and/or modify it
+# under the terms of version 2.1 of the GNU Lesser General Public License as
+# published by the Free Software Foundation.
+#
+# This library is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License
+# for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this library; if not, see <http://www.gnu.org/licenses>.
+#
+
+from cgroup import Cgroup, CgroupVersion
+import consts
+import ftests
+import os
+import sys
+
+CONTROLLER='memory'
+CGNAME="015 cgget"
+
+SETTING='memory.stat'
+VALUE='512'
+
+def prereqs(config):
+    result = consts.TEST_PASSED
+    cause = None
+
+    return result, cause
+
+def setup(config):
+    Cgroup.create(config, CONTROLLER, CGNAME)
+
+def test(config):
+    result = consts.TEST_PASSED
+    cause = None
+
+    out = Cgroup.get(config, controller=None, cgname=CGNAME,
+                     setting=SETTING, print_headers=True,
+                     values_only=False)
+
+    # arbitrary check to ensure we read several lines
+    if len(out.splitlines()) < 10:
+        result = consts.TEST_FAILED
+        cause = "Expected multiple lines, but only received {}".format(
+                len(out.splitlines()))
+        return result, cause
+
+    # arbitrary check for a setting that's in both cgroup v1 and cgroup v2
+    # memory.stat
+    if not "\tunevictable" in out:
+        result = consts.TEST_FAILED
+        cause = "Unexpected output\n{}".format(out)
+        return result, cause
+
+    return result, cause
+
+def teardown(config):
+    Cgroup.delete(config, CONTROLLER, CGNAME)
+
+def main(config):
+    [result, cause] = prereqs(config)
+    if result != consts.TEST_PASSED:
+        return [result, cause]
+
+    setup(config)
+    [result, cause] = test(config)
+    teardown(config)
+
+    return [result, cause]
+
+if __name__ == '__main__':
+    config = ftests.parse_args()
+    # this test was invoked directly.  run only it
+    config.args.num = int(os.path.basename(__file__).split('-')[0])
+    sys.exit(ftests.main(config))

--- a/ftests/016-cgget-invalid_options.py
+++ b/ftests/016-cgget-invalid_options.py
@@ -1,0 +1,203 @@
+#!/usr/bin/env python3
+#
+# Advanced cgget functionality test - multiple '-g' flags
+#
+# Copyright (c) 2021 Oracle and/or its affiliates.
+# Author: Tom Hromatka <tom.hromatka@oracle.com>
+#
+
+#
+# This library is free software; you can redistribute it and/or modify it
+# under the terms of version 2.1 of the GNU Lesser General Public License as
+# published by the Free Software Foundation.
+#
+# This library is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License
+# for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this library; if not, see <http://www.gnu.org/licenses>.
+#
+
+from cgroup import Cgroup, CgroupVersion
+import consts
+import ftests
+import os
+from run import RunError
+import sys
+
+CONTROLLER = 'cpu'
+CGNAME = '016cgget'
+
+def prereqs(config):
+    result = consts.TEST_PASSED
+    cause = None
+
+    # Github Actions has issues with cgget and the code coverage profiler.
+    # This causes issues with the error handling of this test
+    if not config.args.container:
+        result = consts.TEST_SKIPPED
+        cause = "This test cannot be run outside of a container"
+        return result, cause
+
+    return result, cause
+
+def setup(config):
+    Cgroup.create(config, CONTROLLER, CGNAME)
+
+def test(config):
+    result = consts.TEST_PASSED
+    cause = None
+
+    try:
+        # cgget -g cpu
+        Cgroup.get(config, controller=CONTROLLER)
+    except RunError as re:
+        if not "Wrong input parameters," in re.stderr:
+            result = consts.TEST_FAILED
+            cause = "#1 Expected 'Wrong input parameters' to be in stderr"
+            return result, cause
+
+        if re.ret != 255:
+            result = consts.TEST_FAILED
+            cause = "#1 Expected return code of 255 but received {}".format(re.ret)
+            return result, cause
+    else:
+        result = consts.TEST_FAILED
+        cause = "Test case #1 erroneously passed"
+        return result, cause
+
+    try:
+        # cgget -g cpu:016cgget 016cgget
+        Cgroup.get(config, controller="{}:{}".format(CONTROLLER, CGNAME),
+                   cgname=CGNAME)
+    except RunError as re:
+        if not "Wrong input parameters," in re.stderr:
+            result = consts.TEST_FAILED
+            cause = "#2 Expected 'Wrong input parameters' to be in stderr"
+            return result, cause
+
+        if re.ret != 255:
+            result = consts.TEST_FAILED
+            cause = "#2 Expected return code of 255 but received {}".format(re.ret)
+            return result, cause
+    else:
+        result = consts.TEST_FAILED
+        cause = "Test case #2 erroneously passed"
+        return result, cause
+
+    try:
+        # cgget -r invalidsetting 016cgget
+        Cgroup.get(config, setting="invalidsetting", cgname=CGNAME,
+                   print_headers=False, values_only=True)
+    except RunError as re:
+        if not "cgget: error parsing parameter name" in re.stderr:
+            result = consts.TEST_FAILED
+            cause = "#3 Expected 'cgget: error parsing parameter name' to be in stderr"
+            return result, cause
+
+        # legacy cgget returns 0 but populates stderr for this case.
+        # This feels wrong, so the updated cgget returns ECGINVAL
+        if re.ret != 91 and re.ret != 0:
+            result = consts.TEST_FAILED
+            cause = "#3 Expected return code of 0 or 91 but received {}".format(
+                    re.ret)
+            return result, cause
+    else:
+        result = consts.TEST_FAILED
+        cause = "Test case #3 erroneously passed"
+        return result, cause
+
+    try:
+        # cgget -r invalid.setting 016cgget
+        Cgroup.get(config, setting="invalid.setting", cgname=CGNAME,
+                   print_headers=False, values_only=True)
+    except RunError as re:
+        if not "cgget: cannot find controller" in re.stderr:
+            result = consts.TEST_FAILED
+            cause = "#4 Expected 'cgget: cannot find controller' to be in stderr"
+            return result, cause
+
+        # legacy cgget returns 0 but populates stderr for this case.
+        # This feels wrong, so the updated cgget returns ECGOTHER
+        if re.ret != 96 and re.ret != 0:
+            result = consts.TEST_FAILED
+            cause = "#4 Expected return code of 0 or 96 but received {}".format(
+                    re.ret)
+            return result, cause
+    else:
+        result = consts.TEST_FAILED
+        cause = "Test case #4 erroneously passed"
+        return result, cause
+
+    try:
+        # cgget -r cpu.invalid 016cgget
+        Cgroup.get(config, setting="{}.invalid".format(CONTROLLER),
+                   cgname=CGNAME, print_headers=False, values_only=True)
+    except RunError as re:
+        if not "variable file read failed" in re.stderr:
+            result = consts.TEST_FAILED
+            cause = "#5 Expected 'variable file read failed' to be in stderr"
+            return result, cause
+
+        # legacy cgget returns 0 but populates stderr for this case.
+        # This feels wrong, so the updated cgget returns ECGOTHER
+        if re.ret != 96 and re.ret != 0:
+            result = consts.TEST_FAILED
+            cause = "#5 Expected return code of 0 or 96 but received {}".format(
+                    re.ret)
+            return result, cause
+    else:
+        result = consts.TEST_FAILED
+        cause = "Test case #5 erroneously passed"
+        return result, cause
+
+    try:
+        # cgget with no parameters
+        Cgroup.get(config, controller=None, cgname=None, setting=None,
+                   print_headers=True, values_only=False,
+                   all_controllers=False, cghelp=False)
+    except RunError as re:
+        if not "Wrong input parameters," in re.stderr:
+            result = consts.TEST_FAILED
+            cause = "#6 Expected 'Wrong input parameters' to be in stderr"
+            return result, cause
+
+        if re.ret != 1:
+            result = consts.TEST_FAILED
+            cause = "#6 Expected return code of 1 but received {}".format(re.ret)
+            return result, cause
+    else:
+        result = consts.TEST_FAILED
+        cause = "Test case #6 erroneously passed"
+        return result, cause
+
+    # cgget -h
+    ret = Cgroup.get(config, cghelp=True)
+    if not "Print parameter(s)" in ret:
+        result = consts.TEST_FAILED
+        cause = "#7 Failed to print help text"
+        return result, cause
+
+    return result, cause
+
+def teardown(config):
+    Cgroup.delete(config, CONTROLLER, CGNAME)
+
+def main(config):
+    [result, cause] = prereqs(config)
+    if result != consts.TEST_PASSED:
+        return [result, cause]
+
+    setup(config)
+    [result, cause] = test(config)
+    teardown(config)
+
+    return [result, cause]
+
+if __name__ == '__main__':
+    config = ftests.parse_args()
+    # this test was invoked directly.  run only it
+    config.args.num = int(os.path.basename(__file__).split('-')[0])
+    sys.exit(ftests.main(config))

--- a/ftests/cgroup.py
+++ b/ftests/cgroup.py
@@ -236,7 +236,7 @@ class Cgroup(object):
         if config.args.container:
             ret = config.container.run(cmd)
         else:
-            ret = Run.run(cmd).decode('ascii')
+            ret = Run.run(cmd)
 
         return ret
 
@@ -372,7 +372,7 @@ class Cgroup(object):
         if config.args.container:
             res = config.container.run(cmd)
         else:
-            res = Run.run(cmd).decode('ascii')
+            res = Run.run(cmd)
 
         # convert the cgsnapshot stdout to a dict of cgroup objects
         return Cgroup.snapshot_to_dict(res)

--- a/ftests/cgroup.py
+++ b/ftests/cgroup.py
@@ -167,25 +167,29 @@ class Cgroup(object):
             Run.run(cmd)
 
     @staticmethod
-    # valid cpuset commands:
-    #     Read one setting:
-    #         cgget -r cpuset.cpus tomcpuset
-    #     Read two settings:
-    #         cgget -r cpuset.cpus -r cpuset.cpu_exclusive tomcpuset
-    #     Read one setting from two cgroups:
-    #         cgget -r cpuset.cpu_exclusive tomcgroup1 tomcgroup2
-    #     Read two settings from two cgroups:
-    #         cgget -r cpuset.cpu_exclusive -r cpuset.cpu_exclusive tomcgroup1 tomcgroup2
-    #
-    #     Read all of the settings in a cgroup
-    #         cgget -g cpuset tomcpuset
-    #     Read all of the settings in multiple controllers
-    #         cgget -g cpuset -g cpu -g memory tomcgroup
-    #     Read all of the settings from a cgroup at a specific path
-    #         cgget -g memory:tomcgroup/tomcgroup
     def get(config, controller=None, cgname=None, setting=None,
             print_headers=True, values_only=False,
             all_controllers=False, cghelp=False):
+        """cgget equivalent method
+
+        Returns:
+        str: The stdout result of cgget
+
+        The following variants of cgget() are being tested by the
+        automated functional tests:
+
+        Command                                          Test Number
+        cgget -r cpuset.cpus mycg                                001
+        cgget -r cpuset.cpus -r cpuset.mems mycg                 008
+        cgget -g cpu mycg                                        009
+        cgget -g cpu:mycg                                        010
+        cgget -r cpuset.cpus mycg1 mycg2                         011
+        cgget -r cpuset.cpus -r cpuset.mems mycg1 mycg2          012
+        cgget -g cpu -g freezer mycg                             013
+        cgget -a mycg                                            014
+        cgget -r memory.stat mycg (multiline value read)         015
+        various invalid flag combinations                        016
+        """
         cmd = list()
         cmd.append(Cgroup.build_cmd_path('cgget'))
 

--- a/ftests/cgroup.py
+++ b/ftests/cgroup.py
@@ -185,7 +185,7 @@ class Cgroup(object):
     #         cgget -g memory:tomcgroup/tomcgroup
     def get(config, controller=None, cgname=None, setting=None,
             print_headers=True, values_only=False,
-            all_controllers=False):
+            all_controllers=False, cghelp=False):
         cmd = list()
         cmd.append(Cgroup.build_cmd_path('cgget'))
 
@@ -232,6 +232,9 @@ class Cgroup(object):
             elif isinstance(cgname, list):
                 for cg in cgname:
                     cmd.append(cg)
+
+        if cghelp:
+            cmd.append('-h')
 
         if config.args.container:
             ret = config.container.run(cmd)

--- a/ftests/container.py
+++ b/ftests/container.py
@@ -148,7 +148,7 @@ class Container(object):
         else:
             raise ContainerError('Unsupported command type')
 
-        return Run.run(cmd, shell_bool=shell_bool).decode('ascii')
+        return Run.run(cmd, shell_bool=shell_bool)
 
     def start(self):
         cmd = list()

--- a/ftests/process.py
+++ b/ftests/process.py
@@ -71,7 +71,7 @@ class Process(object):
         if config.args.container:
             pid = config.container.run(cmd, shell_bool=True)
         else:
-            pid = Run.run(cmd, shell_bool=True).decode('ascii')
+            pid = Run.run(cmd, shell_bool=True)
 
             for _pid in pid.splitlines():
                 self.children_pids.append(_pid)
@@ -117,7 +117,7 @@ class Process(object):
         if config.args.container:
             ret = config.container.run(cmd)
         else:
-            ret = Run.run(cmd).decode('ascii')
+            ret = Run.run(cmd)
 
         for line in ret.splitlines():
             # cgroup v1 appears in /proc/{pid}/cgroup like the following:
@@ -157,7 +157,7 @@ class Process(object):
         if config.args.container:
             ret = config.container.run(cmd)
         else:
-            ret = Run.run(cmd).decode('ascii')
+            ret = Run.run(cmd)
 
         for line in ret.splitlines():
             # cgroup v2 appears in /proc/{pid}/cgroup like the following:

--- a/ftests/run.py
+++ b/ftests/run.py
@@ -53,7 +53,7 @@ class Run(object):
                 "run:\n\tcommand = {}\n\tret = {}\n\tstdout = {}\n\tstderr = {}".format(
                 ' '.join(command), ret, out, err))
 
-        if ret != 0:
+        if ret != 0 or len(err) > 0:
             raise RunError("Command '{}' failed".format(''.join(command)),
                            command, ret, out, err)
 

--- a/ftests/run.py
+++ b/ftests/run.py
@@ -41,8 +41,8 @@ class Run(object):
         out, err = subproc.communicate()
         ret = subproc.returncode
 
-        out = out.strip()
-        err = err.strip()
+        out = out.strip().decode('ascii')
+        err = err.strip().decode('ascii')
 
         if shell_bool:
             Log.log_debug(


### PR DESCRIPTION
cgget.c does not utilize struct cgroup and other fundamental
building blocks that are central to libcgroup; rather it uses
aarrays of strings.  This is problematic as we continue to
make progress toward a cgroup v1/v2 abstraction layer because
the building blocks within cgget are so disparate from the
rest of the code base.

This patchset adds extensive cgget functional tests to ensure
that we don't break core functionality.  It is envisioned
that these exact tests should pass for the rewritten cgget.

No changes have been made to the libcgroup code base, but
this patchset is based upon the latest cgrules patchset here:
https://github.com/drakenclimber/libcgroup/tree/issues/cgrules4

Test code is available here:
https://github.com/drakenclimber/libcgroup-tests/tree/issues/cgget-tests

Automated test results are available here:
https://github.com/drakenclimber/libcgroup/runs/1882894399

Code coverage increased 1.7% to 45.0%:
https://coveralls.io/builds/37071338