### PR TITLE
gtest: Add unit test for cgset's parse_r_flag()

### DIFF
--- a/gunit/016-cgset_parse_r_flag.cpp
+++ b/gunit/016-cgset_parse_r_flag.cpp
@@ -1,0 +1,52 @@
+/**
+ * libcgroup googletest for parse_r_flag() in cgset
+ *
+ * Copyright (c) 2021 Oracle and/or its affiliates.
+ * Author: Tom Hromatka <tom.hromatka@oracle.com>
+ */
+
+/*
+ * This library is free software; you can redistribute it and/or modify it
+ * under the terms of version 2.1 of the GNU Lesser General Public License as
+ * published by the Free Software Foundation.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library; if not, see <http://www.gnu.org/licenses>.
+ */
+
+#include <ftw.h>
+
+#include "gtest/gtest.h"
+
+#include "libcgroup-internal.h"
+#include "tools-common.h"
+
+static const char * const PARENT_DIR = "test016cgset/";
+
+static const char * const NAME = "io.max";
+static const char * const VALUE = "\"8:16 wbps=1024\"";
+
+class CgsetParseRFlagTest : public ::testing::Test {
+};
+
+TEST_F(CgsetParseRFlagTest, EqualCharInValue)
+{
+	struct control_value name_value;
+	char name_value_str[4092];
+	int ret;
+
+	ret = snprintf(name_value_str, sizeof(name_value_str) -1,
+		       "%s=%s", NAME, VALUE);
+	ASSERT_GT(ret, 0);
+
+	ret = parse_r_flag("cgset", name_value_str, &name_value);
+	ASSERT_EQ(ret, 0);
+
+	ASSERT_STREQ(name_value.name, NAME);
+	ASSERT_STREQ(name_value.value, VALUE);
+}

--- a/gunit/Makefile.am
+++ b/gunit/Makefile.am
@@ -21,13 +21,15 @@
 
 AM_CPPFLAGS = -I$(top_srcdir)/include \
 	      -I$(top_srcdir)/src \
+	      -I$(top_srcdir)/src/tools \
 	      -I$(top_builddir)/googletest/googletest/include \
 	      -I$(top_builddir)/googletest/googletest \
 	      -std=c++11 \
 	      -Wno-write-strings \
 	      -DSTATIC= \
 	      -DUNIT_TEST
-LDADD = $(top_builddir)/src/.libs/libcgroupfortesting.la
+LDADD = $(top_builddir)/src/.libs/libcgroupfortesting.la \
+	$(top_builddir)/src/tools/.libs/libcgset.la
 
 EXTRA_DIST = $(top_srcdir)/googletest/googletest/libgtest.so \
 	     $(top_srcdir)/googletest/googletest/libgtest_main.so \
@@ -52,6 +54,7 @@ gtest_SOURCES = gtest.cpp \
 		012-cgroup_create_cgroup.cpp \
 		013-cgroup_build_tasks_procs_path.cpp \
 		014-cgroupv2_get_subtree_control.cpp \
-		015-cgroupv2_controller_enabled.cpp
+		015-cgroupv2_controller_enabled.cpp \
+		016-cgset_parse_r_flag.cpp
 gtest_LDFLAGS = -L$(top_builddir)/googletest/googletest -l:libgtest.so \
 		-rpath $(abs_top_builddir)/googletest/googletest


### PR DESCRIPTION
Add a unit test for parse_r_flag() in cgset.c.

[----------] 1 test from CgsetParseRFlagTest
[ RUN      ] CgsetParseRFlagTest.EqualCharInValue
[       OK ] CgsetParseRFlagTest.EqualCharInValue (0 ms)
[----------] 1 test from CgsetParseRFlagTest (0 ms total)

Signed-off-by: Tom Hromatka <tom.hromatka@oracle.com>