### PR TITLE
ftests: Add cgget test with no flags

### DIFF
--- a/ftests/033-cgget-no_flags.py
+++ b/ftests/033-cgget-no_flags.py
@@ -1,0 +1,77 @@
+#!/usr/bin/env python3
+#
+# Advanced cgget functionality test - no flags, only a cgroup
+#
+# Copyright (c) 2021 Oracle and/or its affiliates.
+# Author: Tom Hromatka <tom.hromatka@oracle.com>
+#
+
+#
+# This library is free software; you can redistribute it and/or modify it
+# under the terms of version 2.1 of the GNU Lesser General Public License as
+# published by the Free Software Foundation.
+#
+# This library is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License
+# for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this library; if not, see <http://www.gnu.org/licenses>.
+#
+
+from cgroup import Cgroup, CgroupVersion
+import consts
+import ftests
+import os
+import sys
+
+CONTROLLER = 'cpuset'
+CGNAME = '033cgget'
+
+def prereqs(config):
+    result = consts.TEST_PASSED
+    cause = None
+
+    return result, cause
+
+def setup(config):
+    Cgroup.create(config, CONTROLLER, CGNAME)
+
+def test(config):
+    result = consts.TEST_PASSED
+    cause = None
+
+    out = Cgroup.get(config, controller=None, cgname=CGNAME)
+
+    if out.splitlines()[0] != "{}:".format(CGNAME):
+        result = consts.TEST_FAILED
+        cause = "cgget expected the cgroup name {} in the first line.\n" \
+                "Instead it received {}".format(CGNAME, out.splitlines()[0])
+
+    if len(out.splitlines()) < 5:
+        result = consts.TEST_FAILED
+        cause = "Too few lines output by cgget.  Received {} lines".format(
+                len(out.splitlines()))
+
+    return result, cause
+
+def teardown(config):
+    Cgroup.delete(config, CONTROLLER, CGNAME)
+
+def main(config):
+    [result, cause] = prereqs(config)
+    if result != consts.TEST_PASSED:
+        return [result, cause]
+
+    setup(config)
+    [result, cause] = test(config)
+    teardown(config)
+
+    return [result, cause]
+
+if __name__ == '__main__':
+    config = ftests.parse_args()
+    # this test was invoked directly.  run only it
+    config.args.num = int(os.path.basename(__file__).split('-')[0])
+    sys.exit(ftests.main(config))


### PR DESCRIPTION
Add a cgget test that exercises the following format:
	cgget CgroupName

```
-----------------------------------------------------------------
Test Results:
        Run Date:                          Apr 14 10:57:44
        Passed:                                  1 test(s)
        Skipped:                                 0 test(s)
        Failed:                                  0 test(s)
-----------------------------------------------------------------
Timing Results:
        Test                                    Time (sec)
        ---------------------------------------------------------
        setup                                         0.00
        033-cgget-no_flags.py                         0.11
        teardown                                      0.00
        ---------------------------------------------------------
        Total Run Time                                0.11
```

Signed-off-by: Tom Hromatka <tom.hromatka@oracle.com>