### PR TITLE
Add support for full cgroup v2 systems

### DIFF
--- a/ftests/005-cgsnapshot-basic_snapshot_v2.py
+++ b/ftests/005-cgsnapshot-basic_snapshot_v2.py
@@ -56,7 +56,8 @@ def test(config):
     expected = Cgroup.snapshot_to_dict(CGSNAPSHOT)
     actual = Cgroup.snapshot(config, controller=CONTROLLER)
 
-    if expected[CGNAME] != actual[CGNAME]:
+    if expected[CGNAME].controllers[CONTROLLER] != \
+       actual[CGNAME].controllers[CONTROLLER]:
         result = consts.TEST_FAILED
         cause = "Expected cgsnapshot result did not equal actual cgsnapshot"
 

--- a/ftests/009-cgget-g_flag_controller_only.py
+++ b/ftests/009-cgget-g_flag_controller_only.py
@@ -29,13 +29,28 @@ import sys
 CONTROLLER = 'cpu'
 CGNAME = '009cgget'
 
-EXPECTED_OUT = '''009cgget:
+EXPECTED_OUT_V1 = '''009cgget:
 cpu.cfs_period_us: 100000
 cpu.stat: nr_periods 0
         nr_throttled 0
         throttled_time 0
 cpu.shares: 1024
 cpu.cfs_quota_us: -1
+cpu.uclamp.min: 0.00
+cpu.uclamp.max: max
+'''
+
+EXPECTED_OUT_V2 = '''009cgget:
+cpu.weight: 100
+cpu.stat: usage_usec 0
+        user_usec 0
+        system_usec 0
+        nr_periods 0
+        nr_throttled 0
+        throttled_usec 0
+cpu.weight.nice: 0
+cpu.pressure: some avg10=0.00 avg60=0.00 avg300=0.00 total=0
+cpu.max: max 100000
 cpu.uclamp.min: 0.00
 cpu.uclamp.max: max
 '''
@@ -55,11 +70,24 @@ def test(config):
 
     out = Cgroup.get(config, controller=CONTROLLER, cgname=CGNAME)
 
+    version = CgroupVersion.get_version(CONTROLLER)
+
+    if version == CgroupVersion.CGROUP_V1:
+        expected_out = EXPECTED_OUT_V1
+    elif version == CgroupVersion.CGROUP_V2:
+        expected_out = EXPECTED_OUT_V2
+
+    if len(out.splitlines()) != len(expected_out.splitlines()):
+        result = consts.TEST_FAILED
+        cause = "Expected {} lines but received {} lines".format(
+                len(expected_out.splitlines()), len(out.splitlines()))
+        return result, cause
+
     for line_num, line in enumerate(out.splitlines()):
-        if line.strip() != EXPECTED_OUT.splitlines()[line_num].strip():
+        if line.strip() != expected_out.splitlines()[line_num].strip():
             result = consts.TEST_FAILED
             cause = "Expected line:\n\t{}\nbut received line:\n\t{}".format(
-                    EXPECTED_OUT.splitlines()[line_num].strip(), line.strip())
+                    expected_out.splitlines()[line_num].strip(), line.strip())
             return result, cause
 
     return result, cause

--- a/ftests/010-cgget-g_flag_controller_and_cgroup.py
+++ b/ftests/010-cgget-g_flag_controller_and_cgroup.py
@@ -29,12 +29,26 @@ import sys
 CONTROLLER = 'cpu'
 CGNAME = '010cgget'
 
-EXPECTED_OUT = '''cpu.cfs_period_us: 100000
+EXPECTED_OUT_V1 = '''cpu.cfs_period_us: 100000
 cpu.stat: nr_periods 0
         nr_throttled 0
         throttled_time 0
 cpu.shares: 1024
 cpu.cfs_quota_us: -1
+cpu.uclamp.min: 0.00
+cpu.uclamp.max: max
+'''
+
+EXPECTED_OUT_V2 = '''cpu.weight: 100
+cpu.stat: usage_usec 0
+        user_usec 0
+        system_usec 0
+        nr_periods 0
+        nr_throttled 0
+        throttled_usec 0
+cpu.weight.nice: 0
+cpu.pressure: some avg10=0.00 avg60=0.00 avg300=0.00 total=0
+cpu.max: max 100000
 cpu.uclamp.min: 0.00
 cpu.uclamp.max: max
 '''
@@ -55,11 +69,30 @@ def test(config):
     out = Cgroup.get(config, controller="{}:{}".format(CONTROLLER, CGNAME),
                      print_headers=False)
 
+    version = CgroupVersion.get_version(CONTROLLER)
+
+    if version == CgroupVersion.CGROUP_V1:
+        expected_out = EXPECTED_OUT_V1
+    elif version == CgroupVersion.CGROUP_V2:
+        expected_out = EXPECTED_OUT_V2
+
+    if len(out.splitlines()) != len(expected_out.splitlines()):
+        result = consts.TEST_FAILED
+        cause = "Expected line count: {}, but received line count: {}".format(
+                len(expected_out.splitlines()), len(out.splitlines()))
+        return result, cause
+
+    if len(out.splitlines()) != len(expected_out.splitlines()):
+        result = consts.TEST_FAILED
+        cause = "Expected {} lines but received {} lines".format(
+                len(expected_out.splitlines()), len(out.splitlines()))
+        return result, cause
+
     for line_num, line in enumerate(out.splitlines()):
-        if line.strip() != EXPECTED_OUT.splitlines()[line_num].strip():
+        if line.strip() != expected_out.splitlines()[line_num].strip():
             result = consts.TEST_FAILED
             cause = "Expected line:\n\t{}\nbut received line:\n\t{}".format(
-                    EXPECTED_OUT.splitlines()[line_num].strip(), line.strip())
+                    expected_out.splitlines()[line_num].strip(), line.strip())
             return result, cause
 
     return result, cause

--- a/ftests/014-cgget-a_flag.py
+++ b/ftests/014-cgget-a_flag.py
@@ -37,8 +37,17 @@ def prereqs(config):
     return result, cause
 
 def setup(config):
-    Cgroup.create(config, CONTROLLER1, CGNAME)
-    Cgroup.create(config, CONTROLLER2, CGNAME)
+    ver1 = CgroupVersion.get_version(CONTROLLER1)
+    ver2 = CgroupVersion.get_version(CONTROLLER2)
+
+    if ver1 == CgroupVersion.CGROUP_V2 and \
+       ver2 == CgroupVersion.CGROUP_V2:
+        # If both controllers are cgroup v2, then we only need to make
+        # one cgroup.  The path will be the same for both
+        Cgroup.create(config, [CONTROLLER1, CONTROLLER2], CGNAME)
+    else:
+        Cgroup.create(config, CONTROLLER1, CGNAME)
+        Cgroup.create(config, CONTROLLER2, CGNAME)
 
 def test(config):
     result = consts.TEST_PASSED
@@ -69,8 +78,17 @@ def test(config):
     return result, cause
 
 def teardown(config):
-    Cgroup.delete(config, CONTROLLER1, CGNAME)
-    Cgroup.delete(config, CONTROLLER2, CGNAME)
+    ver1 = CgroupVersion.get_version(CONTROLLER1)
+    ver2 = CgroupVersion.get_version(CONTROLLER2)
+
+    if ver1 == CgroupVersion.CGROUP_V2 and \
+       ver2 == CgroupVersion.CGROUP_V2:
+        # If both controllers are cgroup v2, then we only need to make
+        # one cgroup.  The path will be the same for both
+        Cgroup.delete(config, [CONTROLLER1, CONTROLLER2], CGNAME)
+    else:
+        Cgroup.delete(config, CONTROLLER1, CGNAME)
+        Cgroup.delete(config, CONTROLLER2, CGNAME)
 
 def main(config):
     [result, cause] = prereqs(config)

--- a/ftests/030-lssubsys-lssubsys_all.py
+++ b/ftests/030-lssubsys-lssubsys_all.py
@@ -61,6 +61,10 @@ def test(config):
                 found = True
                 break
 
+            if lsmount == "blkio" and mount.controller == "io":
+                found = True
+                break
+
         if not found:
             result = consts.TEST_FAILED
             cause = "Failed to find {} in lssubsys list".format(

--- a/ftests/031-lscgroup-g_flag.py
+++ b/ftests/031-lscgroup-g_flag.py
@@ -50,6 +50,21 @@ def prereqs(config):
     result = consts.TEST_PASSED
     cause = None
 
+    v2_cnt = 0
+    mount_list = Cgroup.get_cgroup_mounts(config)
+
+    for mount in mount_list:
+        if mount.version == CgroupVersion.CGROUP_V2:
+            v2_cnt += 1
+
+    if v2_cnt > 1:
+        # There is a bug in lscgroup - see issue #50 - where it doesn't
+        # properly list the enabled controllers for a cgroup v2 cgroup.
+        # Skip this test because of this
+        result = consts.TEST_SKIPPED
+        cause = "See Github Issue #50 - lscgroup lists controllers..."
+        return result, cause
+
     return result, cause
 
 def setup(config):

--- a/ftests/032-lscgroup-multiple_g_flags.py
+++ b/ftests/032-lscgroup-multiple_g_flags.py
@@ -56,6 +56,21 @@ def prereqs(config):
     result = consts.TEST_PASSED
     cause = None
 
+    v2_cnt = 0
+    mount_list = Cgroup.get_cgroup_mounts(config)
+
+    for mount in mount_list:
+        if mount.version == CgroupVersion.CGROUP_V2:
+            v2_cnt += 1
+
+    if v2_cnt > 1:
+        # There is a bug in lscgroup - see issue #50 - where it doesn't
+        # properly list the enabled controllers for a cgroup v2 cgroup.
+        # Skip this test because of this
+        result = consts.TEST_SKIPPED
+        cause = "See Github Issue #50 - lscgroup lists controllers..."
+        return result, cause
+
     return result, cause
 
 def setup(config):

--- a/ftests/cgroup.py
+++ b/ftests/cgroup.py
@@ -162,7 +162,7 @@ class Cgroup(object):
             cmd.append('-r')
 
         controllers_and_path = '{}:{}'.format(
-            ''.join(controller_list), cgname)
+            ','.join(controller_list), cgname)
 
         cmd.append('-g')
         cmd.append(controllers_and_path)

--- a/ftests/run.py
+++ b/ftests/run.py
@@ -53,9 +53,16 @@ class Run(object):
                 "run:\n\tcommand = {}\n\tret = {}\n\tstdout = {}\n\tstderr = {}".format(
                 ' '.join(command), ret, out, err))
 
-        if ret != 0 or len(err) > 0:
+        if ret != 0:
             raise RunError("Command '{}' failed".format(''.join(command)),
                            command, ret, out, err)
+        if ret != 0 or len(err) > 0:
+            if err.find("WARNING: cgroup v2 is not fully supported yet") == -1:
+                # LXD throws the above warning on systems that are fully
+                # running cgroup v2.  Ignore this warning, but fail if any
+                # other warnings/errors are raised
+                raise RunError("Command '{}' failed".format(''.join(command)),
+                               command, ret, out, err)
 
         return out
 


### PR DESCRIPTION
Some of the tests require minor changes to run on full cgroup v2 systems.  This patchset makes it so the tests run cleanly on a full cgroup v2 system

Inside an LXC container:
```
-----------------------------------------------------------------
Test Results:
	Run Date:                          Jun 21 20:26:44
	Passed:                                 19 test(s)
	Skipped:                                13 test(s)
	Failed:                                  0 test(s)
-----------------------------------------------------------------
```

Directly on a Ubuntu machine:
```
-----------------------------------------------------------------
Test Results:
	Run Date:                          Jun 21 20:27:06
	Passed:                                 18 test(s)
	Skipped:                                14 test(s)
	Failed:                                  0 test(s)
-----------------------------------------------------------------
```