### PR TITLE
ftests: testcase 013 - remove debug statements

### DIFF
--- a/ftests/013-cgget-multiple_g_flags.py
+++ b/ftests/013-cgget-multiple_g_flags.py
@@ -100,8 +100,6 @@ def test(config):
                     expected_out.splitlines()[line_num].strip(), line.strip())
             return result, cause
 
-    print(result)
-    print(cause)
     return result, cause
 
 def teardown(config):


### PR DESCRIPTION
Remove the debugging statements that print the return values
(result, cause) from testcase 013-cgget-multiple_g_flags.py.
These values show up in ftests.sh.log, otherwise, and might
lead to confusion on how to interpret them.

Signed-off-by: Kamalesh Babulal <kamalesh.babulal@oracle.com>