### PR TITLE
ftests.py: fix test results timing alignment

### DIFF
--- a/ftests/ftests.py
+++ b/ftests/ftests.py
@@ -191,6 +191,7 @@ def run_tests(config):
     passed_tests = []
     failed_tests = []
     skipped_tests = []
+    filename_max = 0
 
     for root, dirs, filenames in os.walk(config.ftest_dir):
         for filename in filenames:
@@ -223,6 +224,9 @@ def run_tests(config):
 
                     if filenum_int in config.skip_list:
                         continue
+
+                    if len(filename) > filename_max:
+                        filename_max = len(filename)
 
                     test = __import__(os.path.splitext(filename)[0])
 
@@ -279,18 +283,18 @@ def run_tests(config):
     global teardown_time
     if config.args.verbose:
         print("Timing Results:")
-        print('\t{}{}'.format('{0: <35}'.format("Test"), '{0: >15}'.format("Time (sec)")))
-        print("\t---------------------------------------------------------")
+        print('\t{}{}'.format('{0: <{1}}'.format("Test", filename_max), '{0: >15}'.format("Time (sec)")))
+        print('\t{}'.format('-' * (filename_max + 15))) # 15 is padding space of "Time (sec)"
         time_str = "{0: 2.2f}".format(setup_time)
-        print('\t{}{}'.format('{0: <35}'.format('setup'), '{0: >15}'.format(time_str)))
+        print('\t{}{}'.format('{0: <{1}}'.format('setup', filename_max), '{0: >15}'.format(time_str)))
 
         all_tests = passed_tests + skipped_tests + failed_tests
         all_tests.sort()
         for test in all_tests:
             time_str = "{0: 2.2f}".format(test[1])
-            print('\t{}{}'.format('{0: <35}'.format(test[0]), '{0: >15}'.format(time_str)))
+            print('\t{}{}'.format('{0: <{1}}'.format(test[0], filename_max), '{0: >15}'.format(time_str)))
         time_str = "{0: 2.2f}".format(teardown_time)
-        print('\t{}{}'.format('{0: <35}'.format('teardown'), '{0: >15}'.format(time_str)))
+        print('\t{}{}'.format('{0: <{1}}'.format('teardown', filename_max), '{0: >15}'.format(time_str)))
 
         total_run_time = setup_time + teardown_time
         for test in passed_tests:
@@ -298,8 +302,8 @@ def run_tests(config):
         for test in failed_tests:
             total_run_time += test[1]
         total_str = "{0: 5.2f}".format(total_run_time)
-        print("\t---------------------------------------------------------")
-        print('\t{}{}'.format('{0: <35}'.format("Total Run Time"), '{0: >15}'.format(total_str)))
+        print('\t{}'.format('-' * (filename_max + 15)))
+        print('\t{}{}'.format('{0: <{1}}'.format("Total Run Time", filename_max), '{0: >15}'.format(total_str)))
 
     return [passed_cnt, failed_cnt, skipped_cnt]
 


### PR DESCRIPTION
The current width length of 35 characters, used as alignment for the
first column in the timing results of ftests.sh.log is not enough and
results in misaligned output. Fix it by assigning the columns format
strings width to the longest filename, calculated just before executing
every testcase. This avoids adjusting the width every time, with newer
testcases. Also, fix the banner separator lines to match the width of
the filename column + 15 (time), dynamically.

without the patch:
```
Timing Results:
        Test                                    Time (sec)
        ---------------------------------------------------------
        setup                                        96.39
        001-cgget-basic_cgget_v1.py                   1.36
        002-cgdelete-recursive_delete.py              4.07
        003-cgget-basic_cgget_v2.py                   0.00
        004-cgsnapshot-basic_snapshot_v1.py           9.41
        005-cgsnapshot-basic_snapshot_v2.py           0.00
        006-cgrules-basic_cgrules_v1.py               0.00
        007-cgrules-basic_cgrules_v2.py               0.00
        008-cgget-multiple_r_flags.py                 1.80
        009-cgget-g_flag_controller_only.py           1.03
        010-cgget-g_flag_controller_and_cgroup.py           1.10
        011-cgget-r_flag_two_cgroups.py               2.34
        012-cgget-multiple_r_flags2.py                3.27
        013-cgget-multiple_g_flags.py                 1.74
        014-cgget-a_flag.py                           1.65
        015-cgget-multiline_r_flag.py                 0.99
        016-cgget-invalid_options.py                  3.30
        017-cgconfig-load_file.py                     1.78
        018-cgconfig-load_dir.py                      2.83
        019-cgconfig-uidgid_dperm_fperm.py            3.40
        020-cgconfig-tasks_perms_owner.py             7.26
        021-cgconfig-invalid_options.py               0.75
        022-cgset-multiple_r_flag.py                  2.21
        023-cgset-copy_from.py                        3.27
        025-cgset-multiple_cgroups.py                 3.14
        026-cgset-multiple_r_multiple_cgroup.py           3.80
        027-cgset-invalid_options.py                  6.42
        029-lssubsys-basic_lssubsys.py                3.60
        030-lssubsys-lssubsys_all.py                  0.72
        031-lscgroup-g_flag.py                        1.81
        032-lscgroup-multiple_g_flags.py              3.20
        033-cgget-no_flags.py                         1.12
        034-cgexec-basic_cgexec.py                    2.49
        teardown                                      0.00
        ---------------------------------------------------------
        Total Run Time                              176.24
PASS ftests.sh (exit status: 0)
```

with the patch:
```
Timing Results:
        Test                                          Time (sec)
        --------------------------------------------------------
        setup                                              95.12
        001-cgget-basic_cgget_v1.py                         1.50
        002-cgdelete-recursive_delete.py                    4.31
        003-cgget-basic_cgget_v2.py                         0.00
        004-cgsnapshot-basic_snapshot_v1.py                 2.68
        005-cgsnapshot-basic_snapshot_v2.py                 0.00
        006-cgrules-basic_cgrules_v1.py                     0.00
        007-cgrules-basic_cgrules_v2.py                     0.00
        008-cgget-multiple_r_flags.py                       1.89
        009-cgget-g_flag_controller_only.py                 1.30
        010-cgget-g_flag_controller_and_cgroup.py           1.20
        011-cgget-r_flag_two_cgroups.py                     6.31
        012-cgget-multiple_r_flags2.py                      3.49
        013-cgget-multiple_g_flags.py                       1.82
        014-cgget-a_flag.py                                 2.36
        015-cgget-multiline_r_flag.py                       1.07
        016-cgget-invalid_options.py                        3.45
        017-cgconfig-load_file.py                           2.58
        018-cgconfig-load_dir.py                            3.08
        019-cgconfig-uidgid_dperm_fperm.py                  3.88
        020-cgconfig-tasks_perms_owner.py                  10.46
        021-cgconfig-invalid_options.py                     0.78
        022-cgset-multiple_r_flag.py                        2.33
        023-cgset-copy_from.py                              3.50
        025-cgset-multiple_cgroups.py                       3.90
        026-cgset-multiple_r_multiple_cgroup.py             4.75
        027-cgset-invalid_options.py                        8.52
        029-lssubsys-basic_lssubsys.py                      1.68
        030-lssubsys-lssubsys_all.py                        0.81
        031-lscgroup-g_flag.py                              2.10
        032-lscgroup-multiple_g_flags.py                    3.49
        033-cgget-no_flags.py                               1.28
        034-cgexec-basic_cgexec.py                          3.21
        teardown                                            0.00
        --------------------------------------------------------
        Total Run Time                                    182.86
PASS ftests.sh (exit status: 0)
```

Signed-off-by: Kamalesh Babulal <kamalesh.babulal@oracle.com>