### PR TITLE
Cgroup v1/v2 Abstraction Layer Tests

### DIFF
--- a/ftests/037-cgxget-cpu_settings.py
+++ b/ftests/037-cgxget-cpu_settings.py
@@ -33,8 +33,23 @@ TABLE = [
     # writesetting, writeval, writever, readsetting, readval, readver
     ['cpu.shares', '512', CgroupVersion.CGROUP_V1, 'cpu.shares', '512', CgroupVersion.CGROUP_V1],
     ['cpu.shares', '512', CgroupVersion.CGROUP_V1, 'cpu.weight', '50', CgroupVersion.CGROUP_V2],
+
     ['cpu.weight', '200', CgroupVersion.CGROUP_V2, 'cpu.shares', '2048', CgroupVersion.CGROUP_V1],
     ['cpu.weight', '200', CgroupVersion.CGROUP_V2, 'cpu.weight', '200', CgroupVersion.CGROUP_V2],
+
+    ['cpu.cfs_quota_us', '10000', CgroupVersion.CGROUP_V1, 'cpu.cfs_quota_us', '10000', CgroupVersion.CGROUP_V1],
+    ['cpu.cfs_period_us', '100000', CgroupVersion.CGROUP_V1, 'cpu.cfs_period_us', '100000', CgroupVersion.CGROUP_V1],
+    ['cpu.cfs_period_us', '50000', CgroupVersion.CGROUP_V1, 'cpu.max', '10000 50000', CgroupVersion.CGROUP_V2],
+
+    ['cpu.cfs_quota_us', '-1', CgroupVersion.CGROUP_V1, 'cpu.cfs_quota_us', '-1', CgroupVersion.CGROUP_V1],
+    ['cpu.cfs_period_us', '100000', CgroupVersion.CGROUP_V1, 'cpu.max', 'max 100000', CgroupVersion.CGROUP_V2],
+
+    ['cpu.max', '5000 25000', CgroupVersion.CGROUP_V2, 'cpu.max', '5000 25000', CgroupVersion.CGROUP_V2],
+    ['cpu.max', '6000 26000', CgroupVersion.CGROUP_V2, 'cpu.cfs_quota_us', '6000', CgroupVersion.CGROUP_V1],
+    ['cpu.max', '7000 27000', CgroupVersion.CGROUP_V2, 'cpu.cfs_period_us', '27000', CgroupVersion.CGROUP_V1],
+
+    ['cpu.max', 'max 40000', CgroupVersion.CGROUP_V2, 'cpu.max', 'max 40000', CgroupVersion.CGROUP_V2],
+    ['cpu.max', 'max 41000', CgroupVersion.CGROUP_V2, 'cpu.cfs_quota_us', '-1', CgroupVersion.CGROUP_V1],
 ]
 
 def prereqs(config):

--- a/ftests/037-cgxget-cpu_settings.py
+++ b/ftests/037-cgxget-cpu_settings.py
@@ -1,0 +1,86 @@
+#!/usr/bin/env python3
+#
+# cgxget functionality test - various cpu settings
+#
+# Copyright (c) 2021-2022 Oracle and/or its affiliates.
+# Author: Tom Hromatka <tom.hromatka@oracle.com>
+#
+
+#
+# This library is free software; you can redistribute it and/or modify it
+# under the terms of version 2.1 of the GNU Lesser General Public License as
+# published by the Free Software Foundation.
+#
+# This library is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License
+# for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this library; if not, see <http://www.gnu.org/licenses>.
+#
+
+from cgroup import Cgroup, CgroupVersion
+import consts
+import ftests
+import os
+import sys
+
+CONTROLLER = 'cpu'
+CGNAME = '037cgxget'
+
+TABLE = [
+    # writesetting, writeval, writever, readsetting, readval, readver
+    ['cpu.shares', '512', CgroupVersion.CGROUP_V1, 'cpu.shares', '512', CgroupVersion.CGROUP_V1],
+    ['cpu.shares', '512', CgroupVersion.CGROUP_V1, 'cpu.weight', '50', CgroupVersion.CGROUP_V2],
+    ['cpu.weight', '200', CgroupVersion.CGROUP_V2, 'cpu.shares', '2048', CgroupVersion.CGROUP_V1],
+    ['cpu.weight', '200', CgroupVersion.CGROUP_V2, 'cpu.weight', '200', CgroupVersion.CGROUP_V2],
+]
+
+def prereqs(config):
+    result = consts.TEST_PASSED
+    cause = None
+
+    return result, cause
+
+def setup(config):
+    Cgroup.create(config, CONTROLLER, CGNAME)
+
+def test(config):
+    result = consts.TEST_PASSED
+    cause = None
+
+    for entry in TABLE:
+        Cgroup.xset(config, cgname=CGNAME, setting=entry[0], value=entry[1],
+                    version=entry[2])
+
+        out = Cgroup.xget(config, cgname=CGNAME, setting=entry[3],
+                          version=entry[5], values_only=True,
+                          print_headers=False)
+        if out != entry[4]:
+            result = consts.TEST_FAILED
+            cause = "After setting {}={}, expected {}={}, but received {}={}".format(
+                    entry[0], entry[1], entry[3], entry[4], entry[3], out)
+            return result, cause
+
+    return result, cause
+
+def teardown(config):
+    Cgroup.delete(config, CONTROLLER, CGNAME)
+
+def main(config):
+    [result, cause] = prereqs(config)
+    if result != consts.TEST_PASSED:
+        return [result, cause]
+
+    setup(config)
+    [result, cause] = test(config)
+    teardown(config)
+
+    return [result, cause]
+
+if __name__ == '__main__':
+    config = ftests.parse_args()
+    # this test was invoked directly.  run only it
+    config.args.num = int(os.path.basename(__file__).split('-')[0])
+    sys.exit(ftests.main(config))

--- a/ftests/038-cgxget-cpuset_settings.py
+++ b/ftests/038-cgxget-cpuset_settings.py
@@ -1,0 +1,116 @@
+#!/usr/bin/env python3
+#
+# cgxget functionality test - various cpuset settings
+#
+# Copyright (c) 2021-2022 Oracle and/or its affiliates.
+# Author: Tom Hromatka <tom.hromatka@oracle.com>
+#
+
+#
+# This library is free software; you can redistribute it and/or modify it
+# under the terms of version 2.1 of the GNU Lesser General Public License as
+# published by the Free Software Foundation.
+#
+# This library is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License
+# for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this library; if not, see <http://www.gnu.org/licenses>.
+#
+
+from cgroup import Cgroup, CgroupVersion
+import consts
+import ftests
+import os
+from run import Run
+import sys
+
+CONTROLLER = 'cpuset'
+CGNAME = '038cgxget'
+
+TABLE = [
+    # writesetting, writeval, writever, readsetting, readval, readver
+    ['cpuset.cpus', '0-1', CgroupVersion.CGROUP_V1, 'cpuset.cpus', '0-1', CgroupVersion.CGROUP_V1],
+    ['cpuset.cpus', '0-1', CgroupVersion.CGROUP_V1, 'cpuset.cpus', '0-1', CgroupVersion.CGROUP_V2],
+    ['cpuset.cpus', '0-1', CgroupVersion.CGROUP_V1, 'cpuset.effective_cpus', '0-1', CgroupVersion.CGROUP_V1],
+    ['cpuset.cpus', '0-1', CgroupVersion.CGROUP_V1, 'cpuset.cpus.effective', '0-1', CgroupVersion.CGROUP_V2],
+    ['cpuset.cpus', '1', CgroupVersion.CGROUP_V2, 'cpuset.cpus', '1', CgroupVersion.CGROUP_V1],
+    ['cpuset.cpus', '1', CgroupVersion.CGROUP_V2, 'cpuset.cpus', '1', CgroupVersion.CGROUP_V2],
+
+    ['cpuset.mems', '0', CgroupVersion.CGROUP_V1, 'cpuset.mems', '0', CgroupVersion.CGROUP_V1],
+    ['cpuset.mems', '0', CgroupVersion.CGROUP_V1, 'cpuset.mems', '0', CgroupVersion.CGROUP_V2],
+    ['cpuset.mems', '0', CgroupVersion.CGROUP_V2, 'cpuset.mems', '0', CgroupVersion.CGROUP_V1],
+    ['cpuset.mems', '0', CgroupVersion.CGROUP_V2, 'cpuset.mems', '0', CgroupVersion.CGROUP_V2],
+    ['cpuset.mems', '0', CgroupVersion.CGROUP_V1, 'cpuset.effective_mems', '0', CgroupVersion.CGROUP_V1],
+    ['cpuset.mems', '0', CgroupVersion.CGROUP_V1, 'cpuset.mems.effective', '0', CgroupVersion.CGROUP_V2],
+
+    ['cpuset.cpu_exclusive', '1', CgroupVersion.CGROUP_V1, 'cpuset.cpu_exclusive', '1', CgroupVersion.CGROUP_V1],
+    ['cpuset.cpu_exclusive', '1', CgroupVersion.CGROUP_V1, 'cpuset.cpus.partition', 'root', CgroupVersion.CGROUP_V2],
+    ['cpuset.cpu_exclusive', '0', CgroupVersion.CGROUP_V1, 'cpuset.cpu_exclusive', '0', CgroupVersion.CGROUP_V1],
+    ['cpuset.cpu_exclusive', '0', CgroupVersion.CGROUP_V1, 'cpuset.cpus.partition', 'member', CgroupVersion.CGROUP_V2],
+
+    ['cpuset.cpus.partition', 'root', CgroupVersion.CGROUP_V2, 'cpuset.cpu_exclusive', '1', CgroupVersion.CGROUP_V1],
+    ['cpuset.cpus.partition', 'root', CgroupVersion.CGROUP_V2, 'cpuset.cpus.partition', 'root', CgroupVersion.CGROUP_V2],
+    ['cpuset.cpus.partition', 'member', CgroupVersion.CGROUP_V2, 'cpuset.cpu_exclusive', '0', CgroupVersion.CGROUP_V1],
+    ['cpuset.cpus.partition', 'member', CgroupVersion.CGROUP_V2, 'cpuset.cpus.partition', 'member', CgroupVersion.CGROUP_V2],
+]
+
+def prereqs(config):
+    result = consts.TEST_PASSED
+    cause = None
+
+    nproc = Run.run('nproc')
+    if int(nproc) < 2:
+        result = consts.TEST_SKIPPED
+        cause = "This test requires 2 or more processors"
+
+    if config.args.container:
+        result = consts.TEST_SKIPPED
+        cause = "This test cannot be run within a container"
+        return result, cause
+
+    return result, cause
+
+def setup(config):
+    Cgroup.create(config, CONTROLLER, CGNAME)
+
+def test(config):
+    result = consts.TEST_PASSED
+    cause = None
+
+    for entry in TABLE:
+        Cgroup.xset(config, cgname=CGNAME, setting=entry[0], value=entry[1],
+                    version=entry[2])
+
+        out = Cgroup.xget(config, cgname=CGNAME, setting=entry[3],
+                          version=entry[5], values_only=True,
+                          print_headers=False)
+        if out != entry[4]:
+            result = consts.TEST_FAILED
+            cause = "After setting {}={}, expected {}={}, but received {}={}".format(
+                    entry[0], entry[1], entry[3], entry[4], entry[3], out)
+            return result, cause
+
+    return result, cause
+
+def teardown(config):
+    Cgroup.delete(config, CONTROLLER, CGNAME)
+
+def main(config):
+    [result, cause] = prereqs(config)
+    if result != consts.TEST_PASSED:
+        return [result, cause]
+
+    setup(config)
+    [result, cause] = test(config)
+    teardown(config)
+
+    return [result, cause]
+
+if __name__ == '__main__':
+    config = ftests.parse_args()
+    # this test was invoked directly.  run only it
+    config.args.num = int(os.path.basename(__file__).split('-')[0])
+    sys.exit(ftests.main(config))

--- a/ftests/039-pybindings-cgxget.py
+++ b/ftests/039-pybindings-cgxget.py
@@ -1,0 +1,130 @@
+#!/usr/bin/env python3
+#
+# cgxget functionality test using the python bindings
+#
+# Copyright (c) 2021-2022 Oracle and/or its affiliates.
+# Author: Tom Hromatka <tom.hromatka@oracle.com>
+#
+
+#
+# This library is free software; you can redistribute it and/or modify it
+# under the terms of version 2.1 of the GNU Lesser General Public License as
+# published by the Free Software Foundation.
+#
+# This library is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License
+# for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this library; if not, see <http://www.gnu.org/licenses>.
+#
+
+from cgroup import CgroupVersion
+from cgroup import Cgroup as CgroupCli
+from libcgroup import Cgroup, Version
+import consts
+import ftests
+import os
+import sys
+
+CONTROLLER = 'cpu'
+CGNAME = "039bindings"
+
+SETTING1 = 'cpu.shares'
+VALUE1 = '4096'
+
+SETTING2 = 'cpu.weight'
+VALUE2 = '400'
+
+def prereqs(config):
+    if config.args.container:
+        result = consts.TEST_SKIPPED
+        cause = "This test cannot be run within a container"
+        return result, cause
+
+    result = consts.TEST_PASSED
+    cause = None
+
+    return result, cause
+
+def setup(config):
+    CgroupCli.create(config, CONTROLLER, CGNAME)
+    if CgroupVersion.get_version('cpu') == CgroupVersion.CGROUP_V1:
+        CgroupCli.set(config, CGNAME, SETTING1, VALUE1)
+    else:
+        CgroupCli.set(config, CGNAME, SETTING2, VALUE2)
+
+def test(config):
+    result = consts.TEST_PASSED
+    cause = None
+
+    cg1 = Cgroup(CGNAME, Version.CGROUP_V1)
+    cg1.add_controller(CONTROLLER)
+    cg1.add_setting(SETTING1)
+
+    cg1.cgxget()
+
+    if len(cg1.controllers) != 1:
+        result = consts.TEST_FAILED
+        cause = "Controller length doesn't match, expected 1, but received {}".format(
+                len(cg1.controllers))
+        return result, cause
+
+    if len(cg1.controllers[CONTROLLER].settings) != 1:
+        result = consts.TEST_FAILED
+        cause = "Settings length doesn't match, expected 1, but received {}".format(
+                len(cg1.controllers[CONTROLLER].settings))
+        return result, cause
+
+    if cg1.controllers[CONTROLLER].settings[SETTING1] != VALUE1:
+        result = consts.TEST_FAILED
+        cause = "Expected {} = {} but received {}".format(SETTING1, VALUE1,
+                cg1.controllers[CONTROLLER].settings[SETTING1])
+        return result, cause
+
+    cg2 = Cgroup(CGNAME, Version.CGROUP_V2)
+    cg2.add_controller(CONTROLLER)
+    cg2.add_setting(SETTING2)
+
+    cg2.cgxget()
+
+    if len(cg2.controllers) != 1:
+        result = consts.TEST_FAILED
+        cause = "Controller length doesn't match, expected 1, but received {}".format(
+                len(cg2.controllers))
+        return result, cause
+
+    if len(cg2.controllers[CONTROLLER].settings) != 1:
+        result = consts.TEST_FAILED
+        cause = "Settings length doesn't match, expected 1, but received {}".format(
+                len(cg2.controllers[CONTROLLER].settings))
+        return result, cause
+
+    if cg2.controllers[CONTROLLER].settings[SETTING2] != VALUE2:
+        result = consts.TEST_FAILED
+        cause = "Expected {} = {} but received {}".format(SETTING2, VALUE2,
+                cg2.controllers[CONTROLLER].settings[SETTING2])
+        return result, cause
+
+    return result, cause
+
+def teardown(config):
+    CgroupCli.delete(config, CONTROLLER, CGNAME)
+
+def main(config):
+    [result, cause] = prereqs(config)
+    if result != consts.TEST_PASSED:
+        return [result, cause]
+
+    setup(config)
+    [result, cause] = test(config)
+    teardown(config)
+
+    return [result, cause]
+
+if __name__ == '__main__':
+    config = ftests.parse_args()
+    # this test was invoked directly.  run only it
+    config.args.num = int(os.path.basename(__file__).split('-')[0])
+    sys.exit(ftests.main(config))

--- a/ftests/040-pybindings-cgxset.py
+++ b/ftests/040-pybindings-cgxset.py
@@ -1,0 +1,118 @@
+#!/usr/bin/env python3
+#
+# cgxset functionality test using the python bindings
+#
+# Copyright (c) 2021-2022 Oracle and/or its affiliates.
+# Author: Tom Hromatka <tom.hromatka@oracle.com>
+#
+
+#
+# This library is free software; you can redistribute it and/or modify it
+# under the terms of version 2.1 of the GNU Lesser General Public License as
+# published by the Free Software Foundation.
+#
+# This library is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License
+# for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this library; if not, see <http://www.gnu.org/licenses>.
+#
+
+from cgroup import Cgroup as CgroupCli
+from cgroup import CgroupVersion as CgroupCliVersion
+from libcgroup import Cgroup, Version
+import consts
+import ftests
+import os
+from run import Run
+import sys
+
+CONTROLLER = 'cpu'
+CGNAME = "040bindings"
+
+SETTING1 = 'cpu.shares'
+VALUE1 = '512'
+
+SETTING2 = 'cpu.weight'
+VALUE2 = '50'
+
+def prereqs(config):
+    if config.args.container:
+        result = consts.TEST_SKIPPED
+        cause = "This test cannot be run within a container"
+        return result, cause
+
+    result = consts.TEST_PASSED
+    cause = None
+
+    return result, cause
+
+def setup(config):
+    user_name = Run.run('whoami', shell_bool=True)
+    group_name = Run.run('groups', shell_bool=True).split(' ')[0]
+
+    CgroupCli.create(config, controller_list=CONTROLLER, cgname=CGNAME,
+                     user_name=user_name, group_name=group_name)
+
+def test(config):
+    result = consts.TEST_PASSED
+    cause = None
+
+    cg1 = Cgroup(CGNAME, Version.CGROUP_V1)
+    cg1.add_controller(CONTROLLER)
+    cg1.add_setting(SETTING1, VALUE1)
+
+    cg1.cgxset()
+
+    value_v1 = CgroupCli.xget(config, setting=SETTING1, print_headers=False,
+                   values_only=True, version=CgroupCliVersion.CGROUP_V1,
+                   cgname=CGNAME)
+
+    if value_v1 != VALUE1:
+        result = consts.TEST_FAILED
+        cause = "Expected {}, but received {}".format(VALUE1, value_v1)
+        return result, cause
+
+    # Set the cpu.shares/cpu.weight to an arbitrary value to ensure
+    # the following v2 cgxset works properly
+    CgroupCli.xset(config, cgname=CGNAME, setting=SETTING1, value="1234",
+                   version=CgroupCliVersion.CGROUP_V1)
+
+    cg2 = Cgroup(CGNAME, Version.CGROUP_V2)
+    cg2.add_controller(CONTROLLER)
+    cg2.add_setting(SETTING2, VALUE2)
+
+    cg2.cgxset()
+
+    value_v2 = CgroupCli.xget(config, setting=SETTING2, print_headers=False,
+                   values_only=True, version=CgroupCliVersion.CGROUP_V2,
+                   cgname=CGNAME)
+
+    if value_v2 != VALUE2:
+        result = consts.TEST_FAILED
+        cause = "Expected {}, but received {}".format(VALUE2, value_v2)
+        return result, cause
+
+    return result, cause
+
+def teardown(config):
+    CgroupCli.delete(config, CONTROLLER, CGNAME)
+
+def main(config):
+    [result, cause] = prereqs(config)
+    if result != consts.TEST_PASSED:
+        return [result, cause]
+
+    setup(config)
+    [result, cause] = test(config)
+    teardown(config)
+
+    return [result, cause]
+
+if __name__ == '__main__':
+    config = ftests.parse_args()
+    # this test was invoked directly.  run only it
+    config.args.num = int(os.path.basename(__file__).split('-')[0])
+    sys.exit(ftests.main(config))

--- a/ftests/041-pybindings-library_version.py
+++ b/ftests/041-pybindings-library_version.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env python3
+#
+# get the library version using the python bindings
+#
+# Copyright (c) 2021-2022 Oracle and/or its affiliates.
+# Author: Tom Hromatka <tom.hromatka@oracle.com>
+#
+
+#
+# This library is free software; you can redistribute it and/or modify it
+# under the terms of version 2.1 of the GNU Lesser General Public License as
+# published by the Free Software Foundation.
+#
+# This library is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License
+# for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this library; if not, see <http://www.gnu.org/licenses>.
+#
+
+from libcgroup import Cgroup
+import consts
+import ftests
+import os
+import sys
+
+def prereqs(config):
+    return consts.TEST_PASSED, None
+
+def setup(config):
+    return consts.TEST_PASSED, None
+
+def test(config):
+    result = consts.TEST_PASSED
+    cause = None
+
+    [major, minor, release] = Cgroup.library_version()
+
+    if not isinstance(major, int):
+        result = consts.TEST_FAILED
+        cause = "Major version failed. Received {}".format(major)
+        return result, cause
+
+    if not isinstance(minor, int):
+        result = consts.TEST_FAILED
+        cause = "Minor version failed. Received {}".format(minor)
+        return result, cause
+
+    if not isinstance(release, int):
+        result = consts.TEST_FAILED
+        cause = "Release version failed. Received {}".format(release)
+        return result, cause
+
+    return result, cause
+
+def teardown(config):
+    pass
+
+def main(config):
+    [result, cause] = prereqs(config)
+    if result != consts.TEST_PASSED:
+        return [result, cause]
+
+    setup(config)
+    [result, cause] = test(config)
+    teardown(config)
+
+    return [result, cause]
+
+if __name__ == '__main__':
+    config = ftests.parse_args()
+    # this test was invoked directly.  run only it
+    config.args.num = int(os.path.basename(__file__).split('-')[0])
+    sys.exit(ftests.main(config))

--- a/ftests/042-cgxget-unmappable.py
+++ b/ftests/042-cgxget-unmappable.py
@@ -1,0 +1,79 @@
+#!/usr/bin/env python3
+#
+# Cgxget test with no mappable settings
+#
+# Copyright (c) 2022 Oracle and/or its affiliates.
+# Author: Tom Hromatka <tom.hromatka@oracle.com>
+#
+
+#
+# This library is free software; you can redistribute it and/or modify it
+# under the terms of version 2.1 of the GNU Lesser General Public License as
+# published by the Free Software Foundation.
+#
+# This library is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License
+# for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this library; if not, see <http://www.gnu.org/licenses>.
+#
+
+from cgroup import Cgroup, CgroupVersion
+import consts
+import ftests
+import os
+import sys
+
+CONTROLLER = 'cpu'
+CGNAME = '042cgxget'
+SETTING = 'cpu.stat'
+
+def prereqs(config):
+    result = consts.TEST_PASSED
+    cause = None
+
+    return result, cause
+
+def setup(config):
+    Cgroup.create(config, CONTROLLER, CGNAME)
+
+def test(config):
+    result = consts.TEST_PASSED
+    cause = None
+
+    if CgroupVersion.get_version(CONTROLLER) == CgroupVersion.CGROUP_V1:
+        # request the opposite version of what this system is running
+        requested_ver = CgroupVersion.CGROUP_V2
+    else:
+        requested_ver = CgroupVersion.CGROUP_V1
+
+    out = Cgroup.xget(config, cgname=CGNAME, setting=SETTING,
+                      version=requested_ver, print_headers=False,
+                      ignore_unmappable=True)
+    if len(out):
+        result = consts.TEST_FAILED
+        cause = "Expected cgxget to return nothing.  Received {}".format(out)
+
+    return result, cause
+
+def teardown(config):
+    Cgroup.delete(config, CONTROLLER, CGNAME)
+
+def main(config):
+    [result, cause] = prereqs(config)
+    if result != consts.TEST_PASSED:
+        return [result, cause]
+
+    setup(config)
+    [result, cause] = test(config)
+    teardown(config)
+
+    return [result, cause]
+
+if __name__ == '__main__':
+    config = ftests.parse_args()
+    # this test was invoked directly.  run only it
+    config.args.num = int(os.path.basename(__file__).split('-')[0])
+    sys.exit(ftests.main(config))

--- a/ftests/cgroup.py
+++ b/ftests/cgroup.py
@@ -124,9 +124,10 @@ class Cgroup(object):
         return os.path.join(consts.LIBCG_MOUNT_POINT,
                             'src/daemon/{}'.format(cmd))
 
-    # TODO - add support for all of the cgcreate options
     @staticmethod
-    def create(config, controller_list, cgname):
+    def create(config, controller_list, cgname, user_name=None,
+               group_name=None, dperm=None, fperm=None, tperm=None,
+               tasks_user_name=None, tasks_group_name=None, cghelp=False):
         if isinstance(controller_list, str):
             controller_list = [controller_list]
 
@@ -135,6 +136,29 @@ class Cgroup(object):
         if not config.args.container:
             cmd.append('sudo')
         cmd.append(Cgroup.build_cmd_path('cgcreate'))
+
+        if user_name is not None and group_name is not None:
+            cmd.append('-a')
+            cmd.append('{}:{}'.format(user_name, group_name))
+
+        if dperm is not None:
+            cmd.append('-d')
+            cmd.append(dperm)
+
+        if fperm is not None:
+            cmd.append('-f')
+            cmd.append(fperm)
+
+        if tperm is not None:
+            cmd.append('-s')
+            cmd.append(tperm)
+
+        if tasks_user_name is not None and tasks_group_name is not None:
+            cmd.append('-t')
+            cmd.append('{}:{}'.format(tasks_user_name, tasks_group_name))
+
+        if cghelp:
+            cmd.append('-h')
 
         controllers_and_path = '{}:{}'.format(
             ','.join(controller_list), cgname)

--- a/ftests/cgroup.py
+++ b/ftests/cgroup.py
@@ -232,32 +232,9 @@ class Cgroup(object):
             return Run.run(cmd)
 
     @staticmethod
-    def get(config, controller=None, cgname=None, setting=None,
-            print_headers=True, values_only=False,
-            all_controllers=False, cghelp=False):
-        """cgget equivalent method
-
-        Returns:
-        str: The stdout result of cgget
-
-        The following variants of cgget() are being tested by the
-        automated functional tests:
-
-        Command                                          Test Number
-        cgget -r cpuset.cpus mycg                                001
-        cgget -r cpuset.cpus -r cpuset.mems mycg                 008
-        cgget -g cpu mycg                                        009
-        cgget -g cpu:mycg                                        010
-        cgget -r cpuset.cpus mycg1 mycg2                         011
-        cgget -r cpuset.cpus -r cpuset.mems mycg1 mycg2          012
-        cgget -g cpu -g freezer mycg                             013
-        cgget -a mycg                                            014
-        cgget -r memory.stat mycg (multiline value read)         015
-        various invalid flag combinations                        016
-        """
-        cmd = list()
-        cmd.append(Cgroup.build_cmd_path('cgget'))
-
+    def __get(config, cmd, controller=None, cgname=None, setting=None,
+              print_headers=True, values_only=False,
+              all_controllers=False, cghelp=False):
         if not print_headers:
             cmd.append('-n')
         if values_only:
@@ -317,6 +294,62 @@ class Cgroup(object):
                     raise re
 
         return ret
+
+    @staticmethod
+    def get(config, controller=None, cgname=None, setting=None,
+            print_headers=True, values_only=False,
+            all_controllers=False, cghelp=False):
+        """cgget equivalent method
+
+        Returns:
+        str: The stdout result of cgget
+
+        The following variants of cgget() are being tested by the
+        automated functional tests:
+
+        Command                                          Test Number
+        cgget -r cpuset.cpus mycg                                001
+        cgget -r cpuset.cpus -r cpuset.mems mycg                 008
+        cgget -g cpu mycg                                        009
+        cgget -g cpu:mycg                                        010
+        cgget -r cpuset.cpus mycg1 mycg2                         011
+        cgget -r cpuset.cpus -r cpuset.mems mycg1 mycg2          012
+        cgget -g cpu -g freezer mycg                             013
+        cgget -a mycg                                            014
+        cgget -r memory.stat mycg (multiline value read)         015
+        various invalid flag combinations                        016
+        """
+        cmd = list()
+        cmd.append(Cgroup.build_cmd_path('cgget'))
+
+        return Cgroup.__get(config, cmd, controller, cgname, setting,
+                            print_headers, values_only, all_controllers,
+                            cghelp)
+
+    @staticmethod
+    def xget(config, controller=None, cgname=None, setting=None,
+             print_headers=True, values_only=False,
+             all_controllers=False, version=CgroupVersion.CGROUP_UNK,
+             cghelp=False, ignore_unmappable=False):
+        """cgxget equivalent method
+
+        Returns:
+        str: The stdout result of cgxget
+        """
+        cmd = list()
+        cmd.append(Cgroup.build_cmd_path('cgxget'))
+
+        if version == CgroupVersion.CGROUP_V1:
+            cmd.append('-1')
+        elif version == CgroupVersion.CGROUP_V2:
+            cmd.append('-2')
+
+        if ignore_unmappable:
+            cmd.append('-i')
+
+        return Cgroup.__get(config, cmd, controller, cgname, setting,
+                            print_headers, values_only, all_controllers,
+                            cghelp)
 
     @staticmethod
     def classify(config, controller, cgname, pid_list, sticky=False,

--- a/ftests/cgroup.py
+++ b/ftests/cgroup.py
@@ -173,29 +173,8 @@ class Cgroup(object):
             Run.run(cmd)
 
     @staticmethod
-    def set(config, cgname=None, setting=None, value=None, copy_from=None,
-            cghelp=False):
-        """cgset equivalent method
-
-        The following variants of cgset are being tested by the
-        automated functional tests:
-
-        Command                                          Test Number
-        cgset -r setting=value cgname                        various
-        cgset -r setting1=val1 -r setting2=val2
-              -r setting3=val2 cgname                            022
-        cgset --copy_from foo bar                                023
-        cgset --copy_from foo bar1 bar2                          024
-        cgset -r setting=value foo bar                           025
-        cgset -r setting1=value1 setting2=value2 foo bar         026
-        various invalid flag combinations                        027
-        """
-        cmd = list()
-
-        if not config.args.container:
-            cmd.append('sudo')
-        cmd.append(Cgroup.build_cmd_path('cgset'))
-
+    def __set(config, cmd, cgname=None, setting=None, value=None,
+              copy_from=None, cghelp=False):
         if setting is not None or value is not None:
             if isinstance(setting, str) and isinstance(value, str):
                 cmd.append('-r')
@@ -230,6 +209,54 @@ class Cgroup(object):
             return config.container.run(cmd)
         else:
             return Run.run(cmd)
+
+    @staticmethod
+    def set(config, cgname=None, setting=None, value=None, copy_from=None,
+            cghelp=False):
+        """cgset equivalent method
+
+        The following variants of cgset are being tested by the
+        automated functional tests:
+
+        Command                                          Test Number
+        cgset -r setting=value cgname                        various
+        cgset -r setting1=val1 -r setting2=val2
+              -r setting3=val2 cgname                            022
+        cgset --copy_from foo bar                                023
+        cgset --copy_from foo bar1 bar2                          024
+        cgset -r setting=value foo bar                           025
+        cgset -r setting1=value1 setting2=value2 foo bar         026
+        various invalid flag combinations                        027
+        """
+        cmd = list()
+        if not config.args.container:
+            cmd.append('sudo')
+        cmd.append(Cgroup.build_cmd_path('cgset'))
+
+        return Cgroup.__set(config, cmd, cgname, setting, value, copy_from,
+                            cghelp)
+
+    @staticmethod
+    def xset(config, cgname=None, setting=None, value=None, copy_from=None,
+             version=CgroupVersion.CGROUP_UNK, cghelp=False,
+             ignore_unmappable=False):
+        """cgxset equivalent method
+        """
+        cmd = list()
+        if not config.args.container:
+            cmd.append('sudo')
+        cmd.append(Cgroup.build_cmd_path('cgxset'))
+
+        if version == CgroupVersion.CGROUP_V1:
+            cmd.append('-1')
+        elif version == CgroupVersion.CGROUP_V2:
+            cmd.append('-2')
+
+        if ignore_unmappable:
+            cmd.append('-i')
+
+        return Cgroup.__set(config, cmd, cgname, setting, value, copy_from,
+                            cghelp)
 
     @staticmethod
     def __get(config, cmd, controller=None, cgname=None, setting=None,


### PR DESCRIPTION
This test patchset accompanies the abstraction patchset/pull request
	[[Patch 00/35] Cgroup v1/v2 Abstraction Layer](https://github.com/libcgroup/libcgroup/pull/80)

Key changes in this patchset:
* Add testing support for cgxget and cgxset
* Add support for all of the cgcreate flags
* Add a cgxget test
* Add a cgxset test
* Add a cgroup_cgxget() test using the python bindings
* Add a cgroup_cgxset() test using the python bindings
* Add a test using the python bindings that gets the library
  version number

The changes to libcgroup are available here:
https://github.com/drakenclimber/libcgroup/tree/issues/cgxget5-pybindings4

The changes to libcgroup-tests are available here:
https://github.com/drakenclimber/libcgroup-tests/tree/issues/cgxget5-pybindings4

Code coverage increased from 51.5% to 53.5%:
https://coveralls.io/builds/45064267

Automated tests are passing and results are here:
https://github.com/drakenclimber/libcgroup/runs/4549430696