### PR TITLE
ENH: Refactor get/compare/fail logic

### DIFF
--- a/ftests/001-cgget-basic_cgget_v1.py
+++ b/ftests/001-cgget-basic_cgget_v1.py
@@ -47,18 +47,9 @@ def setup(config):
     Cgroup.set(config, CGNAME, SETTING, VALUE)
 
 def test(config):
-    result = consts.TEST_PASSED
-    cause = None
+    Cgroup.get_and_validate(config, CGNAME, SETTING, VALUE)
 
-    value = Cgroup.get(config, controller=None, cgname=CGNAME,
-                       setting=SETTING, print_headers=False,
-                       values_only=True)
-
-    if value != VALUE:
-        result = consts.TEST_FAILED
-        cause = "cgget expected {} but received {}".format(VALUE, value)
-
-    return result, cause
+    return consts.TEST_PASSED, None
 
 def teardown(config):
     Cgroup.delete(config, CONTROLLER, CGNAME)

--- a/ftests/003-cgget-basic_cgget_v2.py
+++ b/ftests/003-cgget-basic_cgget_v2.py
@@ -47,18 +47,9 @@ def setup(config):
     Cgroup.set(config, CGNAME, SETTING, VALUE)
 
 def test(config):
-    result = consts.TEST_PASSED
-    cause = None
+    Cgroup.get_and_validate(config, CGNAME, SETTING, VALUE)
 
-    value = Cgroup.get(config, controller=None, cgname=CGNAME,
-                       setting=SETTING, print_headers=False,
-                       values_only=True)
-
-    if value != VALUE:
-        result = consts.TEST_FAILED
-        cause = "cgget expected {} but received {}".format(VALUE, value)
-
-    return result, cause
+    return consts.TEST_PASSED, None
 
 def teardown(config):
     Cgroup.delete(config, CONTROLLER, CGNAME)

--- a/ftests/017-cgconfig-load_file.py
+++ b/ftests/017-cgconfig-load_file.py
@@ -60,36 +60,13 @@ def setup(config):
     f.close()
 
 def test(config):
-    result = consts.TEST_PASSED
-    cause = None
-
     Cgroup.configparser(config, load_file=CONFIG_FILE_NAME)
 
-    period = Cgroup.get(config, cgname=CGNAME, setting='cpu.cfs_period_us',
-                        print_headers=False, values_only=True)
-    if period != CFS_PERIOD:
-            result = consts.TEST_FAILED
-            cause = "cfs_period_us failed.  Expected {}, Received {}".format(
-                    CFS_PERIOD, period)
-            return result, cause
+    Cgroup.get_and_validate(config, CGNAME, 'cpu.cfs_period_us', CFS_PERIOD)
+    Cgroup.get_and_validate(config, CGNAME, 'cpu.cfs_quota_us', CFS_QUOTA)
+    Cgroup.get_and_validate(config, CGNAME, 'cpu.shares', SHARES)
 
-    quota = Cgroup.get(config, cgname=CGNAME, setting='cpu.cfs_quota_us',
-                       print_headers=False, values_only=True)
-    if quota != CFS_QUOTA:
-            result = consts.TEST_FAILED
-            cause = "cfs_quota_us failed.  Expected {}, Received {}".format(
-                    CFS_QUOTA, quota)
-            return result, cause
-
-    shares = Cgroup.get(config, cgname=CGNAME, setting='cpu.shares',
-                        print_headers=False, values_only=True)
-    if shares != SHARES:
-            result = consts.TEST_FAILED
-            cause = "shares failed.  Expected {}, Received {}".format(
-                    SHARES, shares)
-            return result, cause
-
-    return result, cause
+    return consts.TEST_PASSED, None
 
 def teardown(config):
     Cgroup.delete(config, CONTROLLER, CGNAME)

--- a/ftests/018-cgconfig-load_dir.py
+++ b/ftests/018-cgconfig-load_dir.py
@@ -77,53 +77,16 @@ def setup(config):
     f.close()
 
 def test(config):
-    result = consts.TEST_PASSED
-    cause = None
-
     Cgroup.configparser(config, load_dir=CONFIG_FILE_DIR)
 
-    period = Cgroup.get(config, cgname=CGNAME, setting='cpu.cfs_period_us',
-                        print_headers=False, values_only=True)
-    if period != CFS_PERIOD:
-            result = consts.TEST_FAILED
-            cause = "cfs_period_us failed.  Expected {}, Received {}".format(
-                    CFS_PERIOD, period)
-            return result, cause
+    Cgroup.get_and_validate(config, CGNAME, 'cpu.cfs_period_us', CFS_PERIOD)
+    Cgroup.get_and_validate(config, CGNAME, 'cpu.cfs_quota_us', CFS_QUOTA)
+    Cgroup.get_and_validate(config, CGNAME, 'cpu.shares', SHARES)
+    Cgroup.get_and_validate(config, CGNAME, 'memory.limit_in_bytes', LIMIT_IN_BYTES)
+    Cgroup.get_and_validate(config, CGNAME, 'memory.soft_limit_in_bytes',
+                            SOFT_LIMIT_IN_BYTES)
 
-    quota = Cgroup.get(config, cgname=CGNAME, setting='cpu.cfs_quota_us',
-                       print_headers=False, values_only=True)
-    if quota != CFS_QUOTA:
-            result = consts.TEST_FAILED
-            cause = "cfs_quota_us failed.  Expected {}, Received {}".format(
-                    CFS_QUOTA, quota)
-            return result, cause
-
-    shares = Cgroup.get(config, cgname=CGNAME, setting='cpu.shares',
-                        print_headers=False, values_only=True)
-    if shares != SHARES:
-            result = consts.TEST_FAILED
-            cause = "shares failed.  Expected {}, Received {}".format(
-                    SHARES, shares)
-            return result, cause
-
-    limit = Cgroup.get(config, cgname=CGNAME, setting='memory.limit_in_bytes',
-                       print_headers=False, values_only=True)
-    if limit != LIMIT_IN_BYTES:
-            result = consts.TEST_FAILED
-            cause = "limit_in_bytes failed.  Expected {}, Received {}".format(
-                    LIMIT_IN_BYTES, limit)
-            return result, cause
-
-    soft_limit = Cgroup.get(config, cgname=CGNAME,
-                            setting='memory.soft_limit_in_bytes',
-                            print_headers=False, values_only=True)
-    if soft_limit != SOFT_LIMIT_IN_BYTES:
-            result = consts.TEST_FAILED
-            cause = "soft_limit_in_bytes failed.  Expected {}, Received {}".format(
-                    SOFT_LIMIT_IN_BYTES, soft_limit)
-            return result, cause
-
-    return result, cause
+    return consts.TEST_PASSED, None
 
 def teardown(config):
     Cgroup.delete(config, CPU_CTRL, CGNAME)

--- a/ftests/022-cgset-multiple_r_flag.py
+++ b/ftests/022-cgset-multiple_r_flag.py
@@ -49,22 +49,12 @@ def setup(config):
     Cgroup.create(config, CONTROLLER, CGNAME)
 
 def test(config):
-    result = consts.TEST_PASSED
-    cause = None
-
     Cgroup.set(config, cgname=CGNAME, setting=SETTINGS, value=VALUES)
 
     for i, setting in enumerate(SETTINGS):
-        value = Cgroup.get(config, cgname=CGNAME, setting=setting,
-                           print_headers=False, values_only=True)
+        Cgroup.get_and_validate(config, CGNAME, setting, VALUES[i])
 
-        if value != VALUES[i]:
-            result = consts.TEST_FAILED
-            cause = "Expected {} to be set to {}, but received {}".format(
-                    setting, VALUES[i], value)
-            return result, cause
-
-    return result, cause
+    return consts.TEST_PASSED, None
 
 def teardown(config):
     Cgroup.delete(config, CONTROLLER, CGNAME)

--- a/ftests/023-cgset-copy_from.py
+++ b/ftests/023-cgset-copy_from.py
@@ -52,22 +52,12 @@ def setup(config):
     Cgroup.set(config, cgname=SRC_CGNAME, setting=SETTINGS, value=VALUES)
 
 def test(config):
-    result = consts.TEST_PASSED
-    cause = None
-
     Cgroup.set(config, cgname=DST_CGNAME, copy_from=SRC_CGNAME)
 
     for i, setting in enumerate(SETTINGS):
-        value = Cgroup.get(config, cgname=DST_CGNAME, setting=setting,
-                           print_headers=False, values_only=True)
+        Cgroup.get_and_validate(config, DST_CGNAME, setting, VALUES[i])
 
-        if value != VALUES[i]:
-            result = consts.TEST_FAILED
-            cause = "Expected {} to be set to {}, but received {}".format(
-                    setting, VALUES[i], value)
-            return result, cause
-
-    return result, cause
+    return consts.TEST_PASSED, None
 
 def teardown(config):
     Cgroup.delete(config, CONTROLLER, SRC_CGNAME)

--- a/ftests/025-cgset-multiple_cgroups.py
+++ b/ftests/025-cgset-multiple_cgroups.py
@@ -49,28 +49,12 @@ def setup(config):
     Cgroup.create(config, CONTROLLER, CGNAME2)
 
 def test(config):
-    result = consts.TEST_PASSED
-    cause = None
-
     Cgroup.set(config, cgname=[CGNAME1, CGNAME2], setting=SETTING, value=VALUE)
 
-    value = Cgroup.get(config, cgname=CGNAME1, setting=SETTING,
-                       print_headers=False, values_only=True)
-    if value != VALUE:
-            result = consts.TEST_FAILED
-            cause = "Expected {} to be set to {} in {}, but received {}".format(
-                    SETTING, VALUE, CGNAME1, value)
-            return result, cause
+    Cgroup.get_and_validate(config, CGNAME1, SETTING, VALUE)
+    Cgroup.get_and_validate(config, CGNAME2, SETTING, VALUE)
 
-    value = Cgroup.get(config, cgname=CGNAME2, setting=SETTING,
-                       print_headers=False, values_only=True)
-    if value != VALUE:
-            result = consts.TEST_FAILED
-            cause = "Expected {} to be set to {} in {}, but received {}".format(
-                    SETTING, VALUE, CGNAME2, value)
-            return result, cause
-
-    return result, cause
+    return consts.TEST_PASSED, None
 
 def teardown(config):
     Cgroup.delete(config, CONTROLLER, CGNAME1)

--- a/ftests/026-cgset-multiple_r_multiple_cgroup.py
+++ b/ftests/026-cgset-multiple_r_multiple_cgroup.py
@@ -51,23 +51,13 @@ def setup(config):
         Cgroup.create(config, CONTROLLER, cg)
 
 def test(config):
-    result = consts.TEST_PASSED
-    cause = None
-
     Cgroup.set(config, cgname=CGNAMES, setting=SETTINGS, value=VALUES)
 
     for i, setting in enumerate(SETTINGS):
         for cg in CGNAMES:
-            value = Cgroup.get(config, cgname=cg, setting=setting,
-                               print_headers=False, values_only=True)
+            Cgroup.get_and_validate(config, cg, setting, VALUES[i])
 
-            if value != VALUES[i]:
-                result = consts.TEST_FAILED
-                cause = "Expected {} to be set to {} in {}, but received {}".format(
-                    setting, VALUES[i], cg, value)
-                return result, cause
-
-    return result, cause
+    return consts.TEST_PASSED, None
 
 def teardown(config):
     for cg in CGNAMES:

--- a/ftests/035-cgset-set_cgroup_type.py
+++ b/ftests/035-cgset-set_cgroup_type.py
@@ -51,37 +51,15 @@ def prereqs(config):
     return result, cause
 
 def setup(config):
-    result = consts.TEST_PASSED
-    cause = None
-
     Cgroup.create(config, CONTROLLER, CGNAME)
+    Cgroup.get_and_validate(config, CGNAME, SETTING, BEFORE)
 
-
-    before = Cgroup.get(config, controller=None, cgname=CGNAME,
-                        setting=SETTING, print_headers=False,
-                        values_only=True)
-    if before != BEFORE:
-        result = consts.TEST_SKIPPED
-        cause = "Skipping test.  Unexpected value in {}: {}".format(SETTING,
-                    before)
-
-    return result, cause
+    return consts.TEST_PASSED, None
 
 def test(config):
-    result = consts.TEST_PASSED
-    cause = None
+    Cgroup.set_and_validate(config, CGNAME, SETTING, AFTER)
 
-    Cgroup.set(config, CGNAME, SETTING, AFTER)
-
-    after = Cgroup.get(config, controller=None, cgname=CGNAME,
-                       setting=SETTING, print_headers=False,
-                       values_only=True)
-
-    if after != AFTER:
-        result = consts.TEST_FAILED
-        cause = "cgget expected {} but received {}".format(AFTER, after)
-
-    return result, cause
+    return consts.TEST_PASSED, None
 
 def teardown(config):
     Cgroup.delete(config, CONTROLLER, CGNAME)

--- a/ftests/cgroup.py
+++ b/ftests/cgroup.py
@@ -830,3 +830,34 @@ class Cgroup(object):
                     return Run.run(cmd, shell_bool=True)
 
         return None
+
+    @staticmethod
+    def get_and_validate(config, cgname, setting, expected_value):
+        """get the requested setting and validate the value received
+
+        This is a helper method for the functional tests and there is no
+        equivalent libcgroup command line interface.  This method will
+        raise a CgroupError if the comparison fails
+        """
+        value = Cgroup.get(config, controller=None, cgname=cgname,
+                           setting=setting, print_headers=False,
+                           values_only=True)
+
+        if value != expected_value:
+            raise CgroupError("cgget expected {} but received {}".format(
+                              expected_value, value))
+
+    @staticmethod
+    def set_and_validate(config, cgname, setting, value):
+        """set the requested setting and validate the write
+
+        This is a helper method for the functional tests and there is no
+        equivalent libcgroup command line interface.  This method will
+        raise a CgroupError if the comparison fails
+        """
+        Cgroup.set(config, cgname, setting, value)
+        Cgroup.get_and_validate(config, cgname, setting, value)
+
+class CgroupError(Exception):
+    def __init__(self, message):
+        super(CgroupError, self).__init__(message)


### PR DESCRIPTION
Replace the boilerplate copy/paste code of get, compare,
and fail-on-error with calls to Cgroup.get_and_validate()
and Cgroup.set_and_validate().

This is purely a cleanup patchset and is nonfunctional.

Passing test run:
https://github.com/drakenclimber/libcgroup/runs/4902758755

Closes:
https://github.com/libcgroup/libcgroup-tests/issues/31
