### PR TITLE
ftests-nocontainer: remove the skip argument

### DIFF
--- a/ftests/ftests-nocontainer.sh
+++ b/ftests/ftests-nocontainer.sh
@@ -1,2 +1,2 @@
 #!/bin/bash
-./ftests.py -l 10 -L ftests-nocontainer.log --skip 28 --no-container
+./ftests.py -l 10 -L ftests-nocontainer.log --no-container


### PR DESCRIPTION
Commit f852cad3fd64 ("ftests: Delete the cgclear functional test"),
removed the testcase 028-cgclear-basic_cgclear.py. Drop the skip
argument from the ftests-nocontainer.sh to skip the non-existing
testcase.

Suggested-by: Tom Hromatka <tom.hromatka@oracle.com>
Signed-off-by: Kamalesh Babulal <kamalesh.babulal@oracle.com>