### PR TITLE
Introduce vim modeline for python sources

### DIFF
--- a/ftests/001-cgget-basic_cgget_v1.py
+++ b/ftests/001-cgget-basic_cgget_v1.py
@@ -70,3 +70,5 @@ if __name__ == '__main__':
     # this test was invoked directly.  run only it
     config.args.num = int(os.path.basename(__file__).split('-')[0])
     sys.exit(ftests.main(config))
+
+# vim: set et ts=4 sw=4:

--- a/ftests/002-cgdelete-recursive_delete.py
+++ b/ftests/002-cgdelete-recursive_delete.py
@@ -76,3 +76,5 @@ if __name__ == '__main__':
     # this test was invoked directly.  run only it
     config.args.num = int(os.path.basename(__file__).split('-')[0])
     sys.exit(ftests.main(config))
+
+# vim: set et ts=4 sw=4:

--- a/ftests/003-cgget-basic_cgget_v2.py
+++ b/ftests/003-cgget-basic_cgget_v2.py
@@ -70,3 +70,5 @@ if __name__ == '__main__':
     # this test was invoked directly.  run only it
     config.args.num = int(os.path.basename(__file__).split('-')[0])
     sys.exit(ftests.main(config))
+
+# vim: set et ts=4 sw=4:

--- a/ftests/004-cgsnapshot-basic_snapshot_v1.py
+++ b/ftests/004-cgsnapshot-basic_snapshot_v1.py
@@ -120,3 +120,5 @@ if __name__ == '__main__':
     # this test was invoked directly.  run only it
     config.args.num = int(os.path.basename(__file__).split('-')[0])
     sys.exit(ftests.main(config))
+
+# vim: set et ts=4 sw=4:

--- a/ftests/005-cgsnapshot-basic_snapshot_v2.py
+++ b/ftests/005-cgsnapshot-basic_snapshot_v2.py
@@ -82,3 +82,5 @@ if __name__ == '__main__':
     # this test was invoked directly.  run only it
     config.args.num = int(os.path.basename(__file__).split('-')[0])
     sys.exit(ftests.main(config))
+
+# vim: set et ts=4 sw=4:

--- a/ftests/006-cgrules-basic_cgrules_v1.py
+++ b/ftests/006-cgrules-basic_cgrules_v1.py
@@ -99,3 +99,5 @@ if __name__ == '__main__':
     # this test was invoked directly.  run only it
     config.args.num = int(os.path.basename(__file__).split('-')[0])
     sys.exit(ftests.main(config))
+
+# vim: set et ts=4 sw=4:

--- a/ftests/007-cgrules-basic_cgrules_v2.py
+++ b/ftests/007-cgrules-basic_cgrules_v2.py
@@ -97,3 +97,5 @@ if __name__ == '__main__':
     # this test was invoked directly.  run only it
     config.args.num = int(os.path.basename(__file__).split('-')[0])
     sys.exit(ftests.main(config))
+
+# vim: set et ts=4 sw=4:

--- a/ftests/008-cgget-multiple_r_flags.py
+++ b/ftests/008-cgget-multiple_r_flags.py
@@ -106,3 +106,5 @@ if __name__ == '__main__':
     # this test was invoked directly.  run only it
     config.args.num = int(os.path.basename(__file__).split('-')[0])
     sys.exit(ftests.main(config))
+
+# vim: set et ts=4 sw=4:

--- a/ftests/009-cgget-g_flag_controller_only.py
+++ b/ftests/009-cgget-g_flag_controller_only.py
@@ -111,3 +111,5 @@ if __name__ == '__main__':
     # this test was invoked directly.  run only it
     config.args.num = int(os.path.basename(__file__).split('-')[0])
     sys.exit(ftests.main(config))
+
+# vim: set et ts=4 sw=4:

--- a/ftests/010-cgget-g_flag_controller_and_cgroup.py
+++ b/ftests/010-cgget-g_flag_controller_and_cgroup.py
@@ -116,3 +116,5 @@ if __name__ == '__main__':
     # this test was invoked directly.  run only it
     config.args.num = int(os.path.basename(__file__).split('-')[0])
     sys.exit(ftests.main(config))
+
+# vim: set et ts=4 sw=4:

--- a/ftests/011-cgget-r_flag_two_cgroups.py
+++ b/ftests/011-cgget-r_flag_two_cgroups.py
@@ -112,3 +112,5 @@ if __name__ == '__main__':
     # this test was invoked directly.  run only it
     config.args.num = int(os.path.basename(__file__).split('-')[0])
     sys.exit(ftests.main(config))
+
+# vim: set et ts=4 sw=4:

--- a/ftests/012-cgget-multiple_r_flags2.py
+++ b/ftests/012-cgget-multiple_r_flags2.py
@@ -113,3 +113,5 @@ if __name__ == '__main__':
     # this test was invoked directly.  run only it
     config.args.num = int(os.path.basename(__file__).split('-')[0])
     sys.exit(ftests.main(config))
+
+# vim: set et ts=4 sw=4:

--- a/ftests/013-cgget-multiple_g_flags.py
+++ b/ftests/013-cgget-multiple_g_flags.py
@@ -131,3 +131,5 @@ if __name__ == '__main__':
     # this test was invoked directly.  run only it
     config.args.num = int(os.path.basename(__file__).split('-')[0])
     sys.exit(ftests.main(config))
+
+# vim: set et ts=4 sw=4:

--- a/ftests/014-cgget-a_flag.py
+++ b/ftests/014-cgget-a_flag.py
@@ -106,3 +106,5 @@ if __name__ == '__main__':
     # this test was invoked directly.  run only it
     config.args.num = int(os.path.basename(__file__).split('-')[0])
     sys.exit(ftests.main(config))
+
+# vim: set et ts=4 sw=4:

--- a/ftests/015-cgget-multiline_r_flag.py
+++ b/ftests/015-cgget-multiline_r_flag.py
@@ -84,3 +84,5 @@ if __name__ == '__main__':
     # this test was invoked directly.  run only it
     config.args.num = int(os.path.basename(__file__).split('-')[0])
     sys.exit(ftests.main(config))
+
+# vim: set et ts=4 sw=4:

--- a/ftests/016-cgget-invalid_options.py
+++ b/ftests/016-cgget-invalid_options.py
@@ -201,3 +201,5 @@ if __name__ == '__main__':
     # this test was invoked directly.  run only it
     config.args.num = int(os.path.basename(__file__).split('-')[0])
     sys.exit(ftests.main(config))
+
+# vim: set et ts=4 sw=4:

--- a/ftests/017-cgconfig-load_file.py
+++ b/ftests/017-cgconfig-load_file.py
@@ -90,3 +90,5 @@ if __name__ == '__main__':
     # this test was invoked directly.  run only it
     config.args.num = int(os.path.basename(__file__).split('-')[0])
     sys.exit(ftests.main(config))
+
+# vim: set et ts=4 sw=4:

--- a/ftests/018-cgconfig-load_dir.py
+++ b/ftests/018-cgconfig-load_dir.py
@@ -112,3 +112,5 @@ if __name__ == '__main__':
     # this test was invoked directly.  run only it
     config.args.num = int(os.path.basename(__file__).split('-')[0])
     sys.exit(ftests.main(config))
+
+# vim: set et ts=4 sw=4:

--- a/ftests/019-cgconfig-uidgid_dperm_fperm.py
+++ b/ftests/019-cgconfig-uidgid_dperm_fperm.py
@@ -136,3 +136,5 @@ if __name__ == '__main__':
     # this test was invoked directly.  run only it
     config.args.num = int(os.path.basename(__file__).split('-')[0])
     sys.exit(ftests.main(config))
+
+# vim: set et ts=4 sw=4:

--- a/ftests/020-cgconfig-tasks_perms_owner.py
+++ b/ftests/020-cgconfig-tasks_perms_owner.py
@@ -133,3 +133,5 @@ if __name__ == '__main__':
     # this test was invoked directly.  run only it
     config.args.num = int(os.path.basename(__file__).split('-')[0])
     sys.exit(ftests.main(config))
+
+# vim: set et ts=4 sw=4:

--- a/ftests/021-cgconfig-invalid_options.py
+++ b/ftests/021-cgconfig-invalid_options.py
@@ -102,3 +102,5 @@ if __name__ == '__main__':
     # this test was invoked directly.  run only it
     config.args.num = int(os.path.basename(__file__).split('-')[0])
     sys.exit(ftests.main(config))
+
+# vim: set et ts=4 sw=4:

--- a/ftests/022-cgset-multiple_r_flag.py
+++ b/ftests/022-cgset-multiple_r_flag.py
@@ -75,3 +75,5 @@ if __name__ == '__main__':
     # this test was invoked directly.  run only it
     config.args.num = int(os.path.basename(__file__).split('-')[0])
     sys.exit(ftests.main(config))
+
+# vim: set et ts=4 sw=4:

--- a/ftests/023-cgset-copy_from.py
+++ b/ftests/023-cgset-copy_from.py
@@ -79,3 +79,5 @@ if __name__ == '__main__':
     # this test was invoked directly.  run only it
     config.args.num = int(os.path.basename(__file__).split('-')[0])
     sys.exit(ftests.main(config))
+
+# vim: set et ts=4 sw=4:

--- a/ftests/025-cgset-multiple_cgroups.py
+++ b/ftests/025-cgset-multiple_cgroups.py
@@ -76,3 +76,5 @@ if __name__ == '__main__':
     # this test was invoked directly.  run only it
     config.args.num = int(os.path.basename(__file__).split('-')[0])
     sys.exit(ftests.main(config))
+
+# vim: set et ts=4 sw=4:

--- a/ftests/026-cgset-multiple_r_multiple_cgroup.py
+++ b/ftests/026-cgset-multiple_r_multiple_cgroup.py
@@ -79,3 +79,5 @@ if __name__ == '__main__':
     # this test was invoked directly.  run only it
     config.args.num = int(os.path.basename(__file__).split('-')[0])
     sys.exit(ftests.main(config))
+
+# vim: set et ts=4 sw=4:

--- a/ftests/027-cgset-invalid_options.py
+++ b/ftests/027-cgset-invalid_options.py
@@ -165,3 +165,5 @@ if __name__ == '__main__':
     # this test was invoked directly.  run only it
     config.args.num = int(os.path.basename(__file__).split('-')[0])
     sys.exit(ftests.main(config))
+
+# vim: set et ts=4 sw=4:

--- a/ftests/029-lssubsys-basic_lssubsys.py
+++ b/ftests/029-lssubsys-basic_lssubsys.py
@@ -93,3 +93,5 @@ if __name__ == '__main__':
     # this test was invoked directly.  run only it
     config.args.num = int(os.path.basename(__file__).split('-')[0])
     sys.exit(ftests.main(config))
+
+# vim: set et ts=4 sw=4:

--- a/ftests/030-lssubsys-lssubsys_all.py
+++ b/ftests/030-lssubsys-lssubsys_all.py
@@ -100,3 +100,5 @@ if __name__ == '__main__':
     # this test was invoked directly.  run only it
     config.args.num = int(os.path.basename(__file__).split('-')[0])
     sys.exit(ftests.main(config))
+
+# vim: set et ts=4 sw=4:

--- a/ftests/031-lscgroup-g_flag.py
+++ b/ftests/031-lscgroup-g_flag.py
@@ -107,3 +107,5 @@ if __name__ == '__main__':
     # this test was invoked directly.  run only it
     config.args.num = int(os.path.basename(__file__).split('-')[0])
     sys.exit(ftests.main(config))
+
+# vim: set et ts=4 sw=4:

--- a/ftests/032-lscgroup-multiple_g_flags.py
+++ b/ftests/032-lscgroup-multiple_g_flags.py
@@ -125,3 +125,5 @@ if __name__ == '__main__':
     # this test was invoked directly.  run only it
     config.args.num = int(os.path.basename(__file__).split('-')[0])
     sys.exit(ftests.main(config))
+
+# vim: set et ts=4 sw=4:

--- a/ftests/033-cgget-no_flags.py
+++ b/ftests/033-cgget-no_flags.py
@@ -75,3 +75,5 @@ if __name__ == '__main__':
     # this test was invoked directly.  run only it
     config.args.num = int(os.path.basename(__file__).split('-')[0])
     sys.exit(ftests.main(config))
+
+# vim: set et ts=4 sw=4:

--- a/ftests/034-cgexec-basic_cgexec.py
+++ b/ftests/034-cgexec-basic_cgexec.py
@@ -91,3 +91,5 @@ if __name__ == '__main__':
     # this test was invoked directly.  run only it
     config.args.num = int(os.path.basename(__file__).split('-')[0])
     sys.exit(ftests.main(config))
+
+# vim: set et ts=4 sw=4:

--- a/ftests/035-cgset-set_cgroup_type.py
+++ b/ftests/035-cgset-set_cgroup_type.py
@@ -83,3 +83,5 @@ if __name__ == '__main__':
     # this test was invoked directly.  run only it
     config.args.num = int(os.path.basename(__file__).split('-')[0])
     sys.exit(ftests.main(config))
+
+# vim: set et ts=4 sw=4:

--- a/ftests/036-cgset-multi_thread.py
+++ b/ftests/036-cgset-multi_thread.py
@@ -102,3 +102,5 @@ if __name__ == '__main__':
     # this test was invoked directly.  run only it
     config.args.num = int(os.path.basename(__file__).split('-')[0])
     sys.exit(ftests.main(config))
+
+# vim: set et ts=4 sw=4:

--- a/ftests/037-cgxget-cpu_settings.py
+++ b/ftests/037-cgxget-cpu_settings.py
@@ -99,3 +99,5 @@ if __name__ == '__main__':
     # this test was invoked directly.  run only it
     config.args.num = int(os.path.basename(__file__).split('-')[0])
     sys.exit(ftests.main(config))
+
+# vim: set et ts=4 sw=4:

--- a/ftests/038-cgxget-cpuset_settings.py
+++ b/ftests/038-cgxget-cpuset_settings.py
@@ -114,3 +114,5 @@ if __name__ == '__main__':
     # this test was invoked directly.  run only it
     config.args.num = int(os.path.basename(__file__).split('-')[0])
     sys.exit(ftests.main(config))
+
+# vim: set et ts=4 sw=4:

--- a/ftests/039-pybindings-cgxget.py
+++ b/ftests/039-pybindings-cgxget.py
@@ -128,3 +128,5 @@ if __name__ == '__main__':
     # this test was invoked directly.  run only it
     config.args.num = int(os.path.basename(__file__).split('-')[0])
     sys.exit(ftests.main(config))
+
+# vim: set et ts=4 sw=4:

--- a/ftests/040-pybindings-cgxset.py
+++ b/ftests/040-pybindings-cgxset.py
@@ -116,3 +116,5 @@ if __name__ == '__main__':
     # this test was invoked directly.  run only it
     config.args.num = int(os.path.basename(__file__).split('-')[0])
     sys.exit(ftests.main(config))
+
+# vim: set et ts=4 sw=4:

--- a/ftests/041-pybindings-library_version.py
+++ b/ftests/041-pybindings-library_version.py
@@ -74,3 +74,5 @@ if __name__ == '__main__':
     # this test was invoked directly.  run only it
     config.args.num = int(os.path.basename(__file__).split('-')[0])
     sys.exit(ftests.main(config))
+
+# vim: set et ts=4 sw=4:

--- a/ftests/042-cgxget-unmappable.py
+++ b/ftests/042-cgxget-unmappable.py
@@ -77,3 +77,5 @@ if __name__ == '__main__':
     # this test was invoked directly.  run only it
     config.args.num = int(os.path.basename(__file__).split('-')[0])
     sys.exit(ftests.main(config))
+
+# vim: set et ts=4 sw=4:

--- a/ftests/cgroup.py
+++ b/ftests/cgroup.py
@@ -945,3 +945,5 @@ class Cgroup(object):
 class CgroupError(Exception):
     def __init__(self, message):
         super(CgroupError, self).__init__(message)
+
+# vim: set et ts=4 sw=4:

--- a/ftests/config.py
+++ b/ftests/config.py
@@ -63,3 +63,5 @@ class ConfigError(Exception):
     def __str__(self):
         out_str = "ConfigError:\n\tmessage = {}".format(self.message)
         return out_str
+
+# vim: set et ts=4 sw=4:

--- a/ftests/consts.py
+++ b/ftests/consts.py
@@ -45,3 +45,5 @@ TEST_FAILED = "failed"
 TEST_SKIPPED = "skipped"
 
 CGRULES_FILE = "/etc/cgrules.conf"
+
+# vim: set et ts=4 sw=4:

--- a/ftests/container.py
+++ b/ftests/container.py
@@ -189,3 +189,5 @@ class ContainerError(Exception):
     def __str__(self):
         out_str = "ContainerError:\n\tmessage = {}".format(self.message)
         return out_str
+
+# vim: set et ts=4 sw=4:

--- a/ftests/controller.py
+++ b/ftests/controller.py
@@ -67,3 +67,5 @@ class Controller(object):
             return False
 
         return True
+
+# vim: set et ts=4 sw=4:

--- a/ftests/ftests.py
+++ b/ftests/ftests.py
@@ -351,3 +351,5 @@ def main(config):
 if __name__ == '__main__':
     config = parse_args()
     sys.exit(main(config))
+
+# vim: set et ts=4 sw=4:

--- a/ftests/log.py
+++ b/ftests/log.py
@@ -54,3 +54,5 @@ class Log(object):
     @staticmethod
     def log_debug(msg):
         Log.log("DEBUG: {}".format(msg), consts.LOG_DEBUG)
+
+# vim: set et ts=4 sw=4:

--- a/ftests/process.py
+++ b/ftests/process.py
@@ -249,3 +249,5 @@ class Process(object):
             return Process.__get_cgroup_v2(config, pid, controller)
 
         raise ValueError("get_cgroup() shouldn't reach this point")
+
+# vim: set et ts=4 sw=4:

--- a/ftests/run.py
+++ b/ftests/run.py
@@ -80,3 +80,5 @@ class RunError(Exception):
                   self.command, self.ret)
         out_str += "\n\tstdout = {}\n\tstderr = {}".format(self.stdout, self.stderr)
         return out_str
+
+# vim: set et ts=4 sw=4:

--- a/ftests/utils.py
+++ b/ftests/utils.py
@@ -88,3 +88,5 @@ def get_file_permissions(config, filename):
         return config.container.run(cmd, shell_bool=True)
     else:
         return Run.run(cmd, shell_bool=True)
+
+# vim: set et ts=4 sw=4:


### PR DESCRIPTION
Introduce vim modeline to python source files. This sets up the
vim editor to PEP-8 recommend editing style. The vim modeline added:
"# vim: set et ts=4 sw=4:"

'et' converts the tabs to spaces, 'ts' set the tabs indentation/tabstop
to 4 characters and 'sw' sets the shiftwidth to 4 characters.

Signed-off-by: Kamalesh Babulal <kamalesh.babulal@oracle.com>