### PR TITLE
Make testcases PEP8 compliant

### DIFF
--- a/ftests/001-cgget-basic_cgget_v1.py
+++ b/ftests/001-cgget-basic_cgget_v1.py
@@ -23,14 +23,14 @@
 from cgroup import Cgroup, CgroupVersion
 import consts
 import ftests
-import os
 import sys
+import os
 
-CONTROLLER='cpu'
-CGNAME="001cgget"
+CONTROLLER = 'cpu'
+CGNAME = '001cgget'
+SETTING = 'cpu.shares'
+VALUE = '512'
 
-SETTING='cpu.shares'
-VALUE='512'
 
 def prereqs(config):
     result = consts.TEST_PASSED
@@ -38,21 +38,25 @@ def prereqs(config):
 
     if CgroupVersion.get_version('cpu') != CgroupVersion.CGROUP_V1:
         result = consts.TEST_SKIPPED
-        cause = "This test requires the cgroup v1 cpu controller"
+        cause = 'This test requires the cgroup v1 cpu controller'
 
     return result, cause
+
 
 def setup(config):
     Cgroup.create(config, CONTROLLER, CGNAME)
     Cgroup.set(config, CGNAME, SETTING, VALUE)
+
 
 def test(config):
     Cgroup.get_and_validate(config, CGNAME, SETTING, VALUE)
 
     return consts.TEST_PASSED, None
 
+
 def teardown(config):
     Cgroup.delete(config, CONTROLLER, CGNAME)
+
 
 def main(config):
     [result, cause] = prereqs(config)
@@ -64,6 +68,7 @@ def main(config):
     teardown(config)
 
     return [result, cause]
+
 
 if __name__ == '__main__':
     config = ftests.parse_args()

--- a/ftests/002-cgdelete-recursive_delete.py
+++ b/ftests/002-cgdelete-recursive_delete.py
@@ -23,18 +23,19 @@
 from cgroup import Cgroup, CgroupVersion
 import consts
 import ftests
-import os
-from process import Process
 import sys
+import os
 
 CONTROLLER = 'cpuset'
 PARENT = '002cgdelete'
 CHILD = 'childcg'
 GRANDCHILD = 'grandchildcg'
 
+
 def prereqs(config):
     # This test should run on both cgroup v1 and v2
     return consts.TEST_PASSED, None
+
 
 def setup(config):
     Cgroup.create(config, CONTROLLER, PARENT)
@@ -49,16 +50,20 @@ def setup(config):
         # Moving a process from a child cgroup to its parent isn't (easily)
         # supported in cgroup v2 because of cgroup v2's restriction that
         # processes only be located in leaf cgroups
+        grandchild_cgrp_path = os.path.join(PARENT, CHILD, GRANDCHILD)
         config.process.create_process_in_cgroup(config, CONTROLLER,
-                                         os.path.join(PARENT, CHILD, GRANDCHILD))
+                                                grandchild_cgrp_path)
+
 
 def test(config):
     Cgroup.delete(config, CONTROLLER, PARENT, recursive=True)
 
     return consts.TEST_PASSED, None
 
+
 def teardown(config):
     pass
+
 
 def main(config):
     [result, cause] = prereqs(config)
@@ -70,6 +75,7 @@ def main(config):
     teardown(config)
 
     return [result, cause]
+
 
 if __name__ == '__main__':
     config = ftests.parse_args()

--- a/ftests/003-cgget-basic_cgget_v2.py
+++ b/ftests/003-cgget-basic_cgget_v2.py
@@ -23,14 +23,15 @@
 from cgroup import Cgroup, CgroupVersion
 import consts
 import ftests
-import os
 import sys
+import os
 
-CONTROLLER='cpuset'
-CGNAME="003cgget"
+CONTROLLER = 'cpuset'
+CGNAME = '003cgget'
 
-SETTING='cpuset.mems'
-VALUE='0'
+SETTING = 'cpuset.mems'
+VALUE = '0'
+
 
 def prereqs(config):
     result = consts.TEST_PASSED
@@ -38,21 +39,25 @@ def prereqs(config):
 
     if CgroupVersion.get_version('cpuset') != CgroupVersion.CGROUP_V2:
         result = consts.TEST_SKIPPED
-        cause = "This test requires the cgroup v2 cpuset controller"
+        cause = 'This test requires the cgroup v2 cpuset controller'
 
     return result, cause
+
 
 def setup(config):
     Cgroup.create(config, CONTROLLER, CGNAME)
     Cgroup.set(config, CGNAME, SETTING, VALUE)
+
 
 def test(config):
     Cgroup.get_and_validate(config, CGNAME, SETTING, VALUE)
 
     return consts.TEST_PASSED, None
 
+
 def teardown(config):
     Cgroup.delete(config, CONTROLLER, CGNAME)
+
 
 def main(config):
     [result, cause] = prereqs(config)
@@ -64,6 +69,7 @@ def main(config):
     teardown(config)
 
     return [result, cause]
+
 
 if __name__ == '__main__':
     config = ftests.parse_args()

--- a/ftests/004-cgsnapshot-basic_snapshot_v1.py
+++ b/ftests/004-cgsnapshot-basic_snapshot_v1.py
@@ -21,14 +21,14 @@
 #
 
 from cgroup import Cgroup, CgroupVersion
+from run import RunError
 import consts
 import ftests
-import os
-from run import Run
 import sys
+import os
 
-CONTROLLER='memory'
-CGNAME="004cgsnapshot"
+CONTROLLER = 'memory'
+CGNAME = '004cgsnapshot'
 CGSNAPSHOT = """group 004cgsnapshot {
                     memory {
                             memory.use_hierarchy="1";
@@ -39,7 +39,7 @@ CGSNAPSHOT = """group 004cgsnapshot {
                             memory.max_usage_in_bytes="0";
                             memory.oom_control="oom_kill_disable 0
                                 under_oom 0
-                                oom_kill 0"; 
+                                oom_kill 0";
                             memory.limit_in_bytes="9223372036854771712";
                             memory.swappiness="60";
                             memory.kmem.failcnt="0";
@@ -60,24 +60,27 @@ CGSNAPSHOT_SWAP = """                            memory.memsw.failcnt="0";
 CGSNAPSHOT_NOSWAP = """                    }
             }"""
 
+
 def prereqs(config):
     result = consts.TEST_PASSED
     cause = None
 
     if CgroupVersion.get_version('memory') != CgroupVersion.CGROUP_V1:
         result = consts.TEST_SKIPPED
-        cause = "This test requires the cgroup v1 memory controller"
+        cause = 'This test requires the cgroup v1 memory controller'
         return result, cause
 
     if not config.args.container:
         result = consts.TEST_SKIPPED
-        cause = "This test must be run within a container"
+        cause = 'This test must be run within a container'
         return result, cause
 
     return result, cause
 
+
 def setup(config):
     Cgroup.create(config, CONTROLLER, CGNAME)
+
 
 def test(config):
     result = consts.TEST_PASSED
@@ -86,9 +89,9 @@ def test(config):
     try:
         # check if the memsw.failcnt file exists.  if so, add it to the
         # expected snapshot
-        Cgroup.get(config, setting="memory.memsw.failcnt", cgname=CGNAME)
+        Cgroup.get(config, setting='memory.memsw.failcnt', cgname=CGNAME)
         expected_str = CGSNAPSHOT + CGSNAPSHOT_SWAP
-    except:
+    except RunError:
         # memsw files don't exist.  exclude them from the snapshot
         expected_str = CGSNAPSHOT + CGSNAPSHOT_NOSWAP
 
@@ -97,12 +100,14 @@ def test(config):
 
     if expected[CGNAME] != actual[CGNAME]:
         result = consts.TEST_FAILED
-        cause = "Expected cgsnapshot result did not equal actual cgsnapshot"
+        cause = 'Expected cgsnapshot result did not equal actual cgsnapshot'
 
     return result, cause
 
+
 def teardown(config):
     Cgroup.delete(config, CONTROLLER, CGNAME)
+
 
 def main(config):
     [result, cause] = prereqs(config)
@@ -114,6 +119,7 @@ def main(config):
     teardown(config)
 
     return [result, cause]
+
 
 if __name__ == '__main__':
     config = ftests.parse_args()

--- a/ftests/005-cgsnapshot-basic_snapshot_v2.py
+++ b/ftests/005-cgsnapshot-basic_snapshot_v2.py
@@ -23,11 +23,11 @@
 from cgroup import Cgroup, CgroupVersion
 import consts
 import ftests
-import os
 import sys
+import os
 
-CONTROLLER='cpuset'
-CGNAME="005cgsnapshot"
+CONTROLLER = 'cpuset'
+CGNAME = '005cgsnapshot'
 CGSNAPSHOT = """group 005cgsnapshot {
                     cpuset {
                             cpuset.cpus.partition="member";
@@ -36,18 +36,21 @@ CGSNAPSHOT = """group 005cgsnapshot {
                     }
             }"""
 
+
 def prereqs(config):
     result = consts.TEST_PASSED
     cause = None
 
     if CgroupVersion.get_version('cpuset') != CgroupVersion.CGROUP_V2:
         result = consts.TEST_SKIPPED
-        cause = "This test requires the cgroup v2 cpuset controller"
+        cause = 'This test requires the cgroup v2 cpuset controller'
 
     return result, cause
 
+
 def setup(config):
     Cgroup.create(config, CONTROLLER, CGNAME)
+
 
 def test(config):
     result = consts.TEST_PASSED
@@ -59,12 +62,14 @@ def test(config):
     if expected[CGNAME].controllers[CONTROLLER] != \
        actual[CGNAME].controllers[CONTROLLER]:
         result = consts.TEST_FAILED
-        cause = "Expected cgsnapshot result did not equal actual cgsnapshot"
+        cause = 'Expected cgsnapshot result did not equal actual cgsnapshot'
 
     return result, cause
 
+
 def teardown(config):
     Cgroup.delete(config, CONTROLLER, CGNAME)
+
 
 def main(config):
     [result, cause] = prereqs(config)
@@ -76,6 +81,7 @@ def main(config):
     teardown(config)
 
     return [result, cause]
+
 
 if __name__ == '__main__':
     config = ftests.parse_args()

--- a/ftests/007-cgrules-basic_cgrules_v2.py
+++ b/ftests/007-cgrules-basic_cgrules_v2.py
@@ -21,20 +21,21 @@
 #
 
 from cgroup import Cgroup, CgroupVersion
+from process import Process
 import consts
 import ftests
-import os
-from process import Process
 import sys
+import os
 
-CONTROLLER='cpuset'
-CGNAME='007cgrules'
+CONTROLLER = 'cpuset'
+CGNAME = '007cgrules'
 
 # move all perl processes to the 007cgrules cgroup in the
 # cpuset controller
-CGRULE="*:/usr/bin/perl cpuset {}".format(CGNAME)
+CGRULE = '*:/usr/bin/perl cpuset {}'.format(CGNAME)
 
 cg = Cgroup(CGNAME)
+
 
 def prereqs(config):
     result = consts.TEST_PASSED
@@ -42,21 +43,23 @@ def prereqs(config):
 
     if config.args.container:
         result = consts.TEST_SKIPPED
-        cause = "This test cannot be run within a container"
+        cause = 'This test cannot be run within a container'
         return result, cause
 
     if CgroupVersion.get_version('cpuset') != CgroupVersion.CGROUP_V2:
         result = consts.TEST_SKIPPED
-        cause = "This test requires the cgroup v2 cpuset controller"
+        cause = 'This test requires the cgroup v2 cpuset controller'
         return result, cause
 
     return result, cause
+
 
 def setup(config):
     Cgroup.create(config, CONTROLLER, CGNAME)
 
     Cgroup.set_cgrules_conf(config, CGRULE, append=False)
     cg.start_cgrules(config)
+
 
 def test(config):
     result = consts.TEST_PASSED
@@ -68,16 +71,21 @@ def test(config):
     # proc/{pid}/cgroup alsways prepends a '/' to the cgroup path
     if proc_cgroup != os.path.join('/', CGNAME):
         result = consts.TEST_FAILED
-        cause = "PID {} was expected to be in cgroup {} but is in cgroup {}".format(
-                    pid, os.path.join('/', CGNAME), proc_cgroup)
+        cause = (
+                    'PID {} was expected to be in cgroup {} but is in '
+                    'cgroup {}'
+                    ''.format(pid, os.path.join('/', CGNAME), proc_cgroup)
+                )
 
     return result, cause
+
 
 def teardown(config):
     # destroy the child processes
     config.process.join_children(config)
     cg.join_children(config)
     Cgroup.delete(config, CONTROLLER, CGNAME, recursive=False)
+
 
 def main(config):
     [result, cause] = prereqs(config)
@@ -91,6 +99,7 @@ def main(config):
         teardown(config)
 
     return [result, cause]
+
 
 if __name__ == '__main__':
     config = ftests.parse_args()

--- a/ftests/008-cgget-multiple_r_flags.py
+++ b/ftests/008-cgget-multiple_r_flags.py
@@ -23,8 +23,8 @@
 from cgroup import Cgroup, CgroupVersion
 import consts
 import ftests
-import os
 import sys
+import os
 
 CONTROLLER = 'memory'
 CGNAME = '008cgget'
@@ -37,11 +37,13 @@ SETTING2_V1 = 'memory.soft_limit_in_bytes'
 SETTING2_V2 = 'memory.high'
 VALUE2 = '1024000'
 
+
 def prereqs(config):
     result = consts.TEST_PASSED
     cause = None
 
     return result, cause
+
 
 def setup(config):
     Cgroup.create(config, CONTROLLER, CGNAME)
@@ -55,6 +57,7 @@ def setup(config):
         Cgroup.set(config, CGNAME, SETTING1_V2, VALUE1)
         Cgroup.set(config, CGNAME, SETTING2_V2, VALUE2)
 
+
 def test(config):
     result = consts.TEST_PASSED
     cause = None
@@ -62,33 +65,42 @@ def test(config):
     version = CgroupVersion.get_version(CONTROLLER)
 
     if version == CgroupVersion.CGROUP_V1:
-        settings=[SETTING1_V1, SETTING2_V1]
+        settings = [SETTING1_V1, SETTING2_V1]
     elif version == CgroupVersion.CGROUP_V2:
-        settings=[SETTING1_V2, SETTING2_V2]
+        settings = [SETTING1_V2, SETTING2_V2]
 
     out = Cgroup.get(config, controller=None, cgname=CGNAME, setting=settings)
 
-    if out.splitlines()[0] != "{}:".format(CGNAME):
+    if out.splitlines()[0] != '{}:'.format(CGNAME):
         result = consts.TEST_FAILED
-        cause = "cgget expected the cgroup name {} in the first line.\n" \
-                "Instead it received {}".format(CGNAME, out.splitlines()[0])
+        cause = (
+                    'cgget expected the cgroup name {} in the first line.\n'
+                    'Instead it received {}'
+                    ''.format(CGNAME, out.splitlines()[0])
+                )
 
-    if out.splitlines()[1] != "{}: {}".format(settings[0], VALUE1):
+    if out.splitlines()[1] != '{}: {}'.format(settings[0], VALUE1):
         result = consts.TEST_FAILED
-        cause = "cgget expected the following:\n\t" \
-                "{}: {}\nbut received:\n\t{}".format(
-                settings[0], VALUE1, out.splitlines()[1])
+        cause = (
+                    'cgget expected the following:\n\t{}: {}\n'
+                    'but received:\n\t{}'
+                    ''.format(settings[0], VALUE1, out.splitlines()[1])
+                )
 
-    if out.splitlines()[2] != "{}: {}".format(settings[1], VALUE2):
+    if out.splitlines()[2] != '{}: {}'.format(settings[1], VALUE2):
         result = consts.TEST_FAILED
-        cause = "cgget expected the following:\n\t" \
-                "{}: {}\nbut received:\n\t{}".format(
-                settings[1], VALUE2, out.splitlines()[2])
+        cause = (
+                    'cgget expected the following:\n\t{}: {}\n'
+                    'but received:\n\t{}'
+                    ''.format(settings[1], VALUE2, out.splitlines()[2])
+                )
 
     return result, cause
 
+
 def teardown(config):
     Cgroup.delete(config, CONTROLLER, CGNAME)
+
 
 def main(config):
     [result, cause] = prereqs(config)
@@ -100,6 +112,7 @@ def main(config):
     teardown(config)
 
     return [result, cause]
+
 
 if __name__ == '__main__':
     config = ftests.parse_args()

--- a/ftests/009-cgget-g_flag_controller_only.py
+++ b/ftests/009-cgget-g_flag_controller_only.py
@@ -23,8 +23,8 @@
 from cgroup import Cgroup, CgroupVersion
 import consts
 import ftests
-import os
 import sys
+import os
 
 CONTROLLER = 'cpu'
 CGNAME = '009cgget'
@@ -55,14 +55,17 @@ cpu.uclamp.min: 0.00
 cpu.uclamp.max: max
 '''
 
+
 def prereqs(config):
     result = consts.TEST_PASSED
     cause = None
 
     return result, cause
 
+
 def setup(config):
     Cgroup.create(config, CONTROLLER, CGNAME)
+
 
 def test(config):
     result = consts.TEST_PASSED
@@ -79,21 +82,29 @@ def test(config):
 
     if len(out.splitlines()) != len(expected_out.splitlines()):
         result = consts.TEST_FAILED
-        cause = "Expected {} lines but received {} lines".format(
-                len(expected_out.splitlines()), len(out.splitlines()))
+        cause = (
+                    'Expected {} lines but received {} lines'
+                    ''.format(len(expected_out.splitlines()),
+                              len(out.splitlines()))
+                )
         return result, cause
 
     for line_num, line in enumerate(out.splitlines()):
         if line.strip() != expected_out.splitlines()[line_num].strip():
             result = consts.TEST_FAILED
-            cause = "Expected line:\n\t{}\nbut received line:\n\t{}".format(
-                    expected_out.splitlines()[line_num].strip(), line.strip())
+            cause = (
+                        'Expected line:\n\t{}\nbut received line:\n\t{}'
+                        ''.format(expected_out.splitlines()[line_num].strip(),
+                                  line.strip())
+                    )
             return result, cause
 
     return result, cause
 
+
 def teardown(config):
     Cgroup.delete(config, CONTROLLER, CGNAME)
+
 
 def main(config):
     [result, cause] = prereqs(config)
@@ -105,6 +116,7 @@ def main(config):
     teardown(config)
 
     return [result, cause]
+
 
 if __name__ == '__main__':
     config = ftests.parse_args()

--- a/ftests/010-cgget-g_flag_controller_and_cgroup.py
+++ b/ftests/010-cgget-g_flag_controller_and_cgroup.py
@@ -23,8 +23,8 @@
 from cgroup import Cgroup, CgroupVersion
 import consts
 import ftests
-import os
 import sys
+import os
 
 CONTROLLER = 'cpu'
 CGNAME = '010cgget'
@@ -53,20 +53,23 @@ cpu.uclamp.min: 0.00
 cpu.uclamp.max: max
 '''
 
+
 def prereqs(config):
     result = consts.TEST_PASSED
     cause = None
 
     return result, cause
 
+
 def setup(config):
     Cgroup.create(config, CONTROLLER, CGNAME)
+
 
 def test(config):
     result = consts.TEST_PASSED
     cause = None
 
-    out = Cgroup.get(config, controller="{}:{}".format(CONTROLLER, CGNAME),
+    out = Cgroup.get(config, controller='{}:{}'.format(CONTROLLER, CGNAME),
                      print_headers=False)
 
     version = CgroupVersion.get_version(CONTROLLER)
@@ -78,27 +81,38 @@ def test(config):
 
     if len(out.splitlines()) != len(expected_out.splitlines()):
         result = consts.TEST_FAILED
-        cause = "Expected line count: {}, but received line count: {}".format(
-                len(expected_out.splitlines()), len(out.splitlines()))
+        cause = (
+                    'Expected line count: {}, but received line count: {}'
+                    ''.format(len(expected_out.splitlines()),
+                              len(out.splitlines()))
+                )
         return result, cause
 
     if len(out.splitlines()) != len(expected_out.splitlines()):
         result = consts.TEST_FAILED
-        cause = "Expected {} lines but received {} lines".format(
-                len(expected_out.splitlines()), len(out.splitlines()))
+        cause = (
+                    'Expected {} lines but received {} lines'
+                    ''.format(len(expected_out.splitlines()),
+                              len(out.splitlines()))
+                )
         return result, cause
 
     for line_num, line in enumerate(out.splitlines()):
         if line.strip() != expected_out.splitlines()[line_num].strip():
             result = consts.TEST_FAILED
-            cause = "Expected line:\n\t{}\nbut received line:\n\t{}".format(
-                    expected_out.splitlines()[line_num].strip(), line.strip())
+            cause = (
+                        'Expected line:\n\t{}\nbut received line:\n\t{}'
+                        ''.format(expected_out.splitlines()[line_num].strip(),
+                                  line.strip())
+                    )
             return result, cause
 
     return result, cause
 
+
 def teardown(config):
     Cgroup.delete(config, CONTROLLER, CGNAME)
+
 
 def main(config):
     [result, cause] = prereqs(config)
@@ -110,6 +124,7 @@ def main(config):
     teardown(config)
 
     return [result, cause]
+
 
 if __name__ == '__main__':
     config = ftests.parse_args()

--- a/ftests/011-cgget-r_flag_two_cgroups.py
+++ b/ftests/011-cgget-r_flag_two_cgroups.py
@@ -23,8 +23,8 @@
 from cgroup import Cgroup, CgroupVersion
 import consts
 import ftests
-import os
 import sys
+import os
 
 CONTROLLER = 'memory'
 CGNAME1 = '011cgget1'
@@ -48,11 +48,13 @@ memory.max: 2048000
 memory.max: 2048000
 '''
 
+
 def prereqs(config):
     result = consts.TEST_PASSED
     cause = None
 
     return result, cause
+
 
 def setup(config):
     Cgroup.create(config, CONTROLLER, CGNAME1)
@@ -66,6 +68,7 @@ def setup(config):
     elif version == CgroupVersion.CGROUP_V2:
         Cgroup.set(config, CGNAME1, SETTING_V2, VALUE)
         Cgroup.set(config, CGNAME2, SETTING_V2, VALUE)
+
 
 def test(config):
     result = consts.TEST_PASSED
@@ -86,15 +89,20 @@ def test(config):
     for line_num, line in enumerate(out.splitlines()):
         if line.strip() != expected_out.splitlines()[line_num].strip():
             result = consts.TEST_FAILED
-            cause = "Expected line:\n\t{}\nbut received line:\n\t{}".format(
-                    expected_out.splitlines()[line_num].strip(), line.strip())
+            cause = (
+                        'Expected line:\n\t{}\nbut received line:\n\t{}'
+                        ''.format(expected_out.splitlines()[line_num].strip(),
+                                  line.strip())
+                    )
             return result, cause
 
     return result, cause
 
+
 def teardown(config):
     Cgroup.delete(config, CONTROLLER, CGNAME1)
     Cgroup.delete(config, CONTROLLER, CGNAME2)
+
 
 def main(config):
     [result, cause] = prereqs(config)
@@ -106,6 +114,7 @@ def main(config):
     teardown(config)
 
     return [result, cause]
+
 
 if __name__ == '__main__':
     config = ftests.parse_args()

--- a/ftests/012-cgget-multiple_r_flags2.py
+++ b/ftests/012-cgget-multiple_r_flags2.py
@@ -23,8 +23,8 @@
 from cgroup import Cgroup, CgroupVersion
 import consts
 import ftests
-import os
 import sys
+import os
 
 CONTROLLER = 'memory'
 CGNAME1 = '012cgget1'
@@ -47,11 +47,13 @@ EXPECTED_OUT = '''{}:
 {}
 '''.format(CGNAME1, VALUE1, VALUE2, CGNAME2, VALUE1, VALUE2)
 
+
 def prereqs(config):
     result = consts.TEST_PASSED
     cause = None
 
     return result, cause
+
 
 def setup(config):
     Cgroup.create(config, CONTROLLER, CGNAME1)
@@ -70,6 +72,7 @@ def setup(config):
         Cgroup.set(config, CGNAME2, SETTING1_V2, VALUE1)
         Cgroup.set(config, CGNAME2, SETTING2_V2, VALUE2)
 
+
 def test(config):
     result = consts.TEST_PASSED
     cause = None
@@ -87,15 +90,20 @@ def test(config):
     for line_num, line in enumerate(out.splitlines()):
         if line.strip() != EXPECTED_OUT.splitlines()[line_num].strip():
             result = consts.TEST_FAILED
-            cause = "Expected line:\n\t{}\nbut received line:\n\t{}".format(
-                    EXPECTED_OUT.splitlines()[line_num].strip(), line.strip())
+            cause = (
+                        'Expected line:\n\t{}\nbut received line:\n\t{}'
+                        ''.format(EXPECTED_OUT.splitlines()[line_num].strip(),
+                                  line.strip())
+                    )
             return result, cause
 
     return result, cause
 
+
 def teardown(config):
     Cgroup.delete(config, CONTROLLER, CGNAME1)
     Cgroup.delete(config, CONTROLLER, CGNAME2)
+
 
 def main(config):
     [result, cause] = prereqs(config)
@@ -107,6 +115,7 @@ def main(config):
     teardown(config)
 
     return [result, cause]
+
 
 if __name__ == '__main__':
     config = ftests.parse_args()

--- a/ftests/013-cgget-multiple_g_flags.py
+++ b/ftests/013-cgget-multiple_g_flags.py
@@ -23,9 +23,8 @@
 from cgroup import Cgroup, CgroupVersion
 import consts
 import ftests
-import os
-from run import RunError
 import sys
+import os
 
 CONTROLLER1 = 'pids'
 CONTROLLER2 = 'cpu'
@@ -63,15 +62,18 @@ cpu.uclamp.min: 0.00
 cpu.uclamp.max: max
 '''
 
+
 def prereqs(config):
     result = consts.TEST_PASSED
     cause = None
 
     return result, cause
 
+
 def setup(config):
     Cgroup.create(config, CONTROLLER1, CGNAME)
     Cgroup.create(config, CONTROLLER2, CGNAME)
+
 
 def test(config):
     result = consts.TEST_PASSED
@@ -89,18 +91,25 @@ def test(config):
 
     if len(out.splitlines()) != len(expected_out.splitlines()):
         result = consts.TEST_FAILED
-        cause = "Expected {} lines but received {} lines".format(
-                len(expected_out.splitlines()), len(out.splitlines()))
+        cause = (
+                    'Expected {} lines but received {} lines'
+                    ''.format(len(expected_out.splitlines()),
+                              len(out.splitlines()))
+                )
         return result, cause
 
     for line_num, line in enumerate(out.splitlines()):
         if line.strip() != expected_out.splitlines()[line_num].strip():
             result = consts.TEST_FAILED
-            cause = "Expected line:\n\t{}\nbut received line:\n\t{}".format(
-                    expected_out.splitlines()[line_num].strip(), line.strip())
+            cause = (
+                        'Expected line:\n\t{}\nbut received line:\n\t{}'
+                        ''.format(expected_out.splitlines()[line_num].strip(),
+                                  line.strip())
+                    )
             return result, cause
 
     return result, cause
+
 
 def teardown(config):
     ver1 = CgroupVersion.get_version(CONTROLLER1)
@@ -115,6 +124,7 @@ def teardown(config):
         Cgroup.delete(config, CONTROLLER1, CGNAME)
         Cgroup.delete(config, CONTROLLER2, CGNAME)
 
+
 def main(config):
     [result, cause] = prereqs(config)
     if result != consts.TEST_PASSED:
@@ -125,6 +135,7 @@ def main(config):
     teardown(config)
 
     return [result, cause]
+
 
 if __name__ == '__main__':
     config = ftests.parse_args()

--- a/ftests/014-cgget-a_flag.py
+++ b/ftests/014-cgget-a_flag.py
@@ -23,18 +23,20 @@
 from cgroup import Cgroup, CgroupVersion
 import consts
 import ftests
-import os
 import sys
+import os
 
-CONTROLLER1='memory'
-CONTROLLER2='cpuset'
-CGNAME="014cgget"
+CONTROLLER1 = 'memory'
+CONTROLLER2 = 'cpuset'
+CGNAME = '014cgget'
+
 
 def prereqs(config):
     result = consts.TEST_PASSED
     cause = None
 
     return result, cause
+
 
 def setup(config):
     ver1 = CgroupVersion.get_version(CONTROLLER1)
@@ -49,6 +51,7 @@ def setup(config):
         Cgroup.create(config, CONTROLLER1, CGNAME)
         Cgroup.create(config, CONTROLLER2, CGNAME)
 
+
 def test(config):
     result = consts.TEST_PASSED
     cause = None
@@ -58,24 +61,27 @@ def test(config):
     # arbitrary check to ensure we read several lines
     if len(out.splitlines()) < 20:
         result = consts.TEST_FAILED
-        cause = "Expected multiple lines, but only received {}".format(
-                len(out.splitlines()))
+        cause = (
+                    'Expected multiple lines, but only received {}'
+                    ''.format(len(out.splitlines()))
+                )
         return result, cause
 
     # arbitrary check for a setting that's in both cgroup v1 and cgroup v2
     # memory.stat
-    if not "\tpgmajfault" in out:
+    if '\tpgmajfault' not in out:
         result = consts.TEST_FAILED
-        cause = "Unexpected output\n{}".format(out)
+        cause = 'Unexpected output\n{}'.format(out)
         return result, cause
 
     # make sure that a cpuset value was in the output:
-    if not "cpuset.cpus" in out:
+    if 'cpuset.cpus' not in out:
         result = consts.TEST_FAILED
-        cause = "Failed to find cpuset settings in output\n{}".format(out)
+        cause = 'Failed to find cpuset settings in output\n{}'.format(out)
         return result, cause
 
     return result, cause
+
 
 def teardown(config):
     ver1 = CgroupVersion.get_version(CONTROLLER1)
@@ -90,6 +96,7 @@ def teardown(config):
         Cgroup.delete(config, CONTROLLER1, CGNAME)
         Cgroup.delete(config, CONTROLLER2, CGNAME)
 
+
 def main(config):
     [result, cause] = prereqs(config)
     if result != consts.TEST_PASSED:
@@ -100,6 +107,7 @@ def main(config):
     teardown(config)
 
     return [result, cause]
+
 
 if __name__ == '__main__':
     config = ftests.parse_args()

--- a/ftests/015-cgget-multiline_r_flag.py
+++ b/ftests/015-cgget-multiline_r_flag.py
@@ -20,17 +20,18 @@
 # along with this library; if not, see <http://www.gnu.org/licenses>.
 #
 
-from cgroup import Cgroup, CgroupVersion
+from cgroup import Cgroup
 import consts
 import ftests
-import os
 import sys
+import os
 
-CONTROLLER='memory'
-CGNAME="015cgget"
+CONTROLLER = 'memory'
+CGNAME = '015cgget'
 
-SETTING='memory.stat'
-VALUE='512'
+SETTING = 'memory.stat'
+VALUE = '512'
+
 
 def prereqs(config):
     result = consts.TEST_PASSED
@@ -38,8 +39,10 @@ def prereqs(config):
 
     return result, cause
 
+
 def setup(config):
     Cgroup.create(config, CONTROLLER, CGNAME)
+
 
 def test(config):
     result = consts.TEST_PASSED
@@ -52,21 +55,25 @@ def test(config):
     # arbitrary check to ensure we read several lines
     if len(out.splitlines()) < 10:
         result = consts.TEST_FAILED
-        cause = "Expected multiple lines, but only received {}".format(
-                len(out.splitlines()))
+        cause = (
+                    'Expected multiple lines, but only received {}'
+                    ''.format(len(out.splitlines()))
+                )
         return result, cause
 
     # arbitrary check for a setting that's in both cgroup v1 and cgroup v2
     # memory.stat
-    if not "\tunevictable" in out:
+    if '\tunevictable' not in out:
         result = consts.TEST_FAILED
-        cause = "Unexpected output\n{}".format(out)
+        cause = 'Unexpected output\n{}'.format(out)
         return result, cause
 
     return result, cause
 
+
 def teardown(config):
     Cgroup.delete(config, CONTROLLER, CGNAME)
+
 
 def main(config):
     [result, cause] = prereqs(config)
@@ -78,6 +85,7 @@ def main(config):
     teardown(config)
 
     return [result, cause]
+
 
 if __name__ == '__main__':
     config = ftests.parse_args()

--- a/ftests/016-cgget-invalid_options.py
+++ b/ftests/016-cgget-invalid_options.py
@@ -20,15 +20,16 @@
 # along with this library; if not, see <http://www.gnu.org/licenses>.
 #
 
-from cgroup import Cgroup, CgroupVersion
+from cgroup import Cgroup
+from run import RunError
 import consts
 import ftests
-import os
-from run import RunError
 import sys
+import os
 
 CONTROLLER = 'cpu'
 CGNAME = '016cgget'
+
 
 def prereqs(config):
     result = consts.TEST_PASSED
@@ -38,13 +39,15 @@ def prereqs(config):
     # This causes issues with the error handling of this test
     if not config.args.container:
         result = consts.TEST_SKIPPED
-        cause = "This test cannot be run outside of a container"
+        cause = 'This test cannot be run outside of a container'
         return result, cause
 
     return result, cause
 
+
 def setup(config):
     Cgroup.create(config, CONTROLLER, CGNAME)
+
 
 def test(config):
     result = consts.TEST_PASSED
@@ -54,89 +57,105 @@ def test(config):
         # cgget -g cpu
         Cgroup.get(config, controller=CONTROLLER)
     except RunError as re:
-        if not "Wrong input parameters," in re.stderr:
+        if 'Wrong input parameters,' not in re.stderr:
             result = consts.TEST_FAILED
             cause = "#1 Expected 'Wrong input parameters' to be in stderr"
             return result, cause
 
         if re.ret != 255:
             result = consts.TEST_FAILED
-            cause = "#1 Expected return code of 255 but received {}".format(re.ret)
+            cause = (
+                        '#1 Expected return code of 255 but received {}'
+                        ''.format(re.ret)
+                    )
             return result, cause
     else:
         result = consts.TEST_FAILED
-        cause = "Test case #1 erroneously passed"
+        cause = 'Test case #1 erroneously passed'
         return result, cause
 
     try:
         # cgget -g cpu:016cgget 016cgget
-        Cgroup.get(config, controller="{}:{}".format(CONTROLLER, CGNAME),
+        Cgroup.get(config, controller='{}:{}'.format(CONTROLLER, CGNAME),
                    cgname=CGNAME)
     except RunError as re:
-        if not "Wrong input parameters," in re.stderr:
+        if 'Wrong input parameters,' not in re.stderr:
             result = consts.TEST_FAILED
             cause = "#2 Expected 'Wrong input parameters' to be in stderr"
             return result, cause
 
         if re.ret != 255:
             result = consts.TEST_FAILED
-            cause = "#2 Expected return code of 255 but received {}".format(re.ret)
+            cause = (
+                        '#2 Expected return code of 255 but received {}'
+                        ''.format(re.ret)
+                    )
             return result, cause
     else:
         result = consts.TEST_FAILED
-        cause = "Test case #2 erroneously passed"
+        cause = 'Test case #2 erroneously passed'
         return result, cause
 
     try:
         # cgget -r invalidsetting 016cgget
-        Cgroup.get(config, setting="invalidsetting", cgname=CGNAME,
+        Cgroup.get(config, setting='invalidsetting', cgname=CGNAME,
                    print_headers=False, values_only=True)
     except RunError as re:
-        if not "cgget: error parsing parameter name" in re.stderr:
+        if 'cgget: error parsing parameter name' not in re.stderr:
             result = consts.TEST_FAILED
-            cause = "#3 Expected 'cgget: error parsing parameter name' to be in stderr"
+            cause = (
+                        "#3 Expected 'cgget: error parsing parameter name' to "
+                        "be in stderr"
+                    )
             return result, cause
 
         # legacy cgget returns 0 but populates stderr for this case.
         # This feels wrong, so the updated cgget returns ECGINVAL
         if re.ret != 91 and re.ret != 0:
             result = consts.TEST_FAILED
-            cause = "#3 Expected return code of 0 or 91 but received {}".format(
-                    re.ret)
+            cause = (
+                        '#3 Expected return code of 0 or 91 but received {}'
+                        ''.format(re.ret)
+                    )
             return result, cause
     else:
         result = consts.TEST_FAILED
-        cause = "Test case #3 erroneously passed"
+        cause = 'Test case #3 erroneously passed'
         return result, cause
 
     try:
         # cgget -r invalid.setting 016cgget
-        Cgroup.get(config, setting="invalid.setting", cgname=CGNAME,
+        Cgroup.get(config, setting='invalid.setting', cgname=CGNAME,
                    print_headers=False, values_only=True)
     except RunError as re:
-        if not "cgget: cannot find controller" in re.stderr:
+        if 'cgget: cannot find controller' not in re.stderr:
             result = consts.TEST_FAILED
-            cause = "#4 Expected 'cgget: cannot find controller' to be in stderr"
+            cause = (
+                        "#4 Expected 'cgget: cannot find controller' to be in "
+                        "stderr"
+                    )
             return result, cause
 
         # legacy cgget returns 0 but populates stderr for this case.
         # This feels wrong, so the updated cgget returns ECGOTHER
         if re.ret != 96 and re.ret != 0:
             result = consts.TEST_FAILED
-            cause = "#4 Expected return code of 0 or 96 but received {}".format(
-                    re.ret)
+            cause = (
+                        '#4 Expected return code of 0 or 96 but received {}'
+                        ''.format(re.ret)
+                    )
             return result, cause
     else:
         result = consts.TEST_FAILED
-        cause = "Test case #4 erroneously passed"
+        cause = 'Test case #4 erroneously passed'
         return result, cause
 
     try:
         # cgget -r cpu.invalid 016cgget
-        Cgroup.get(config, setting="{}.invalid".format(CONTROLLER),
+        Cgroup.get(config, setting='{}.invalid'.format(CONTROLLER),
                    cgname=CGNAME, print_headers=False, values_only=True)
     except RunError as re:
-        if not "variable file read failed" in re.stderr:
+        if 'variable file read failed' not in re.stderr:
             result = consts.TEST_FAILED
             cause = "#5 Expected 'variable file read failed' to be in stderr"
             return result, cause
@@ -145,12 +164,14 @@ def test(config):
         # This feels wrong, so the updated cgget returns ECGOTHER
         if re.ret != 96 and re.ret != 0:
             result = consts.TEST_FAILED
-            cause = "#5 Expected return code of 0 or 96 but received {}".format(
-                    re.ret)
+            cause = (
+                        '#5 Expected return code of 0 or 96 but received {}'
+                        ''.format(re.ret)
+                    )
             return result, cause
     else:
         result = consts.TEST_FAILED
-        cause = "Test case #5 erroneously passed"
+        cause = 'Test case #5 erroneously passed'
         return result, cause
 
     try:
@@ -159,31 +180,36 @@ def test(config):
                    print_headers=True, values_only=False,
                    all_controllers=False, cghelp=False)
     except RunError as re:
-        if not "Wrong input parameters," in re.stderr:
+        if 'Wrong input parameters,' not in re.stderr:
             result = consts.TEST_FAILED
             cause = "#6 Expected 'Wrong input parameters' to be in stderr"
             return result, cause
 
         if re.ret != 1:
             result = consts.TEST_FAILED
-            cause = "#6 Expected return code of 1 but received {}".format(re.ret)
+            cause = (
+                        '#6 Expected return code of 1 but received {}'
+                        ''.format(re.ret)
+                    )
             return result, cause
     else:
         result = consts.TEST_FAILED
-        cause = "Test case #6 erroneously passed"
+        cause = 'Test case #6 erroneously passed'
         return result, cause
 
     # cgget -h
     ret = Cgroup.get(config, cghelp=True)
-    if not "Print parameter(s)" in ret:
+    if 'Print parameter(s)' not in ret:
         result = consts.TEST_FAILED
-        cause = "#7 Failed to print help text"
+        cause = '#7 Failed to print help text'
         return result, cause
 
     return result, cause
 
+
 def teardown(config):
     Cgroup.delete(config, CONTROLLER, CGNAME)
+
 
 def main(config):
     [result, cause] = prereqs(config)
@@ -195,6 +221,7 @@ def main(config):
     teardown(config)
 
     return [result, cause]
+
 
 if __name__ == '__main__':
     config = ftests.parse_args()

--- a/ftests/017-cgconfig-load_file.py
+++ b/ftests/017-cgconfig-load_file.py
@@ -23,8 +23,8 @@
 from cgroup import Cgroup, CgroupVersion
 import consts
 import ftests
-import os
 import sys
+import os
 
 CONTROLLER = 'cpu'
 CGNAME = '017cgconfig'
@@ -43,21 +43,24 @@ CONFIG_FILE = '''group
 
 CONFIG_FILE_NAME = os.path.join(os.getcwd(), '017cgconfig.conf')
 
+
 def prereqs(config):
     result = consts.TEST_PASSED
     cause = None
 
     if CgroupVersion.get_version('cpu') != CgroupVersion.CGROUP_V1:
         result = consts.TEST_SKIPPED
-        cause = "This test requires the cgroup v1 cpu controller"
+        cause = 'This test requires the cgroup v1 cpu controller'
         return result, cause
 
     return result, cause
+
 
 def setup(config):
     f = open(CONFIG_FILE_NAME, 'w')
     f.write(CONFIG_FILE)
     f.close()
+
 
 def test(config):
     Cgroup.configparser(config, load_file=CONFIG_FILE_NAME)
@@ -68,9 +71,11 @@ def test(config):
 
     return consts.TEST_PASSED, None
 
+
 def teardown(config):
     Cgroup.delete(config, CONTROLLER, CGNAME)
     os.remove(CONFIG_FILE_NAME)
+
 
 def main(config):
     [result, cause] = prereqs(config)
@@ -84,6 +89,7 @@ def main(config):
         teardown(config)
 
     return [result, cause]
+
 
 if __name__ == '__main__':
     config = ftests.parse_args()

--- a/ftests/018-cgconfig-load_dir.py
+++ b/ftests/018-cgconfig-load_dir.py
@@ -23,8 +23,8 @@
 from cgroup import Cgroup, CgroupVersion
 import consts
 import ftests
-import os
 import sys
+import os
 
 CPU_CTRL = 'cpu'
 MEMORY_CTRL = 'memory'
@@ -53,21 +53,23 @@ CONFIG_FILE = '''group
 CONFIG_FILE_DIR = os.path.join(os.getcwd(), '018cgconfig')
 CONFIG_FILE_NAME = os.path.join(CONFIG_FILE_DIR, 'cgconfig.conf')
 
+
 def prereqs(config):
     result = consts.TEST_PASSED
     cause = None
 
     if CgroupVersion.get_version('cpu') != CgroupVersion.CGROUP_V1:
         result = consts.TEST_SKIPPED
-        cause = "This test requires the cgroup v1 cpu controller"
+        cause = 'This test requires the cgroup v1 cpu controller'
         return result, cause
 
     if CgroupVersion.get_version('memory') != CgroupVersion.CGROUP_V1:
         result = consts.TEST_SKIPPED
-        cause = "This test requires the cgroup v1 memory controller"
+        cause = 'This test requires the cgroup v1 memory controller'
         return result, cause
 
     return result, cause
+
 
 def setup(config):
     os.mkdir(CONFIG_FILE_DIR)
@@ -76,23 +78,27 @@ def setup(config):
     f.write(CONFIG_FILE)
     f.close()
 
+
 def test(config):
     Cgroup.configparser(config, load_dir=CONFIG_FILE_DIR)
 
     Cgroup.get_and_validate(config, CGNAME, 'cpu.cfs_period_us', CFS_PERIOD)
     Cgroup.get_and_validate(config, CGNAME, 'cpu.cfs_quota_us', CFS_QUOTA)
     Cgroup.get_and_validate(config, CGNAME, 'cpu.shares', SHARES)
-    Cgroup.get_and_validate(config, CGNAME, 'memory.limit_in_bytes', LIMIT_IN_BYTES)
+    Cgroup.get_and_validate(config, CGNAME, 'memory.limit_in_bytes',
+                            LIMIT_IN_BYTES)
     Cgroup.get_and_validate(config, CGNAME, 'memory.soft_limit_in_bytes',
                             SOFT_LIMIT_IN_BYTES)
 
     return consts.TEST_PASSED, None
+
 
 def teardown(config):
     Cgroup.delete(config, CPU_CTRL, CGNAME)
     Cgroup.delete(config, MEMORY_CTRL, CGNAME)
     os.remove(CONFIG_FILE_NAME)
     os.rmdir(CONFIG_FILE_DIR)
+
 
 def main(config):
     [result, cause] = prereqs(config)
@@ -106,6 +112,7 @@ def main(config):
         teardown(config)
 
     return [result, cause]
+
 
 if __name__ == '__main__':
     config = ftests.parse_args()

--- a/ftests/019-cgconfig-uidgid_dperm_fperm.py
+++ b/ftests/019-cgconfig-uidgid_dperm_fperm.py
@@ -20,13 +20,14 @@
 # along with this library; if not, see <http://www.gnu.org/licenses>.
 #
 
-from cgroup import Cgroup, CgroupVersion
+from container import ContainerError
+from run import Run, RunError
+from cgroup import Cgroup
 import consts
 import ftests
-import os
-from run import Run
-import sys
 import utils
+import sys
+import os
 
 CONTROLLER = 'cpuset'
 CGNAME = '019cgconfig'
@@ -44,11 +45,13 @@ FPERM = '246'
 
 CONFIG_FILE_NAME = os.path.join(os.getcwd(), '019cgconfig.conf')
 
+
 def prereqs(config):
     result = consts.TEST_PASSED
     cause = None
 
     return result, cause
+
 
 def setup(config):
     f = open(CONFIG_FILE_NAME, 'w')
@@ -61,6 +64,7 @@ def setup(config):
     else:
         Run.run(['sudo', 'useradd', '-p', 'Test019#1', USER])
         Run.run(['sudo', 'groupadd', GROUP])
+
 
 def test(config):
     result = consts.TEST_PASSED
@@ -77,31 +81,40 @@ def test(config):
 
     if user != USER:
         result = consts.TEST_FAILED
-        cause = "Owner name failed.  Expected {}, received {}\n".format(
-                USER, user)
+        cause = (
+                    'Owner name failed.  Expected {}, received {}\n'
+                    ''.format(USER, user)
+                )
         return result, cause
 
     if group != GROUP:
         result = consts.TEST_FAILED
-        cause = "Owner group failed.  Expected {}, received {}\n".format(
-                GROUP, group)
+        cause = (
+                    'Owner group failed.  Expected {}, received {}\n'
+                    ''.format(GROUP, group)
+                )
         return result, cause
 
     fperm = utils.get_file_permissions(config, cpus_path)
     if fperm != FPERM:
         result = consts.TEST_FAILED
-        cause = "File permissions failed.  Expected {}, received {}\n".format(
-                FPERM, fperm)
+        cause = (
+                    'File permissions failed.  Expected {}, received {}\n'
+                    ''.format(FPERM, fperm)
+                )
         return result, cause
 
     dperm = utils.get_file_permissions(config, os.path.join(mnt_path, CGNAME))
     if dperm != DPERM:
         result = consts.TEST_FAILED
-        cause = "Directory permissions failed.  Expected {}, received {}\n".format(
-                DPERM, dperm)
+        cause = (
+                    'Directory permissions failed.  Expected {}, received {}\n'
+                    ''.format(DPERM, dperm)
+                )
         return result, cause
 
     return result, cause
+
 
 def teardown(config):
     os.remove(CONFIG_FILE_NAME)
@@ -113,10 +126,11 @@ def teardown(config):
         else:
             Run.run(['sudo', 'userdel', USER])
             Run.run(['sudo', 'groupdel', GROUP])
-    except:
+    except (ContainerError, RunError, ValueError):
         pass
 
     Cgroup.delete(config, CONTROLLER, CGNAME)
+
 
 def main(config):
     [result, cause] = prereqs(config)
@@ -130,6 +144,7 @@ def main(config):
         teardown(config)
 
     return [result, cause]
+
 
 if __name__ == '__main__':
     config = ftests.parse_args()

--- a/ftests/020-cgconfig-tasks_perms_owner.py
+++ b/ftests/020-cgconfig-tasks_perms_owner.py
@@ -21,12 +21,13 @@
 #
 
 from cgroup import Cgroup, CgroupVersion
+from container import ContainerError
+from run import Run, RunError
 import consts
 import ftests
-import os
-from run import Run
-import sys
 import utils
+import sys
+import os
 
 CONTROLLER = 'cpuset'
 CGNAME = '020cgconfig'
@@ -43,16 +44,18 @@ TPERM = '642'
 
 CONFIG_FILE_NAME = os.path.join(os.getcwd(), '020cgconfig.conf')
 
+
 def prereqs(config):
     result = consts.TEST_PASSED
     cause = None
 
     if CgroupVersion.get_version('cpuset') != CgroupVersion.CGROUP_V1:
         result = consts.TEST_SKIPPED
-        cause = "This test requires the cgroup v1 cpuset controller"
+        cause = 'This test requires the cgroup v1 cpuset controller'
         return result, cause
 
     return result, cause
+
 
 def setup(config):
     f = open(CONFIG_FILE_NAME, 'w')
@@ -65,6 +68,7 @@ def setup(config):
     else:
         Run.run(['sudo', 'useradd', '-p', 'Test020#1', USER])
         Run.run(['sudo', 'groupadd', GROUP])
+
 
 def test(config):
     result = consts.TEST_PASSED
@@ -81,24 +85,31 @@ def test(config):
 
     if user != USER:
         result = consts.TEST_FAILED
-        cause = "Owner name failed.  Expected {}, received {}\n".format(
-                USER, user)
+        cause = (
+                    'Owner name failed.  Expected {}, received {}\n'
+                    ''.format(USER, user)
+                )
         return result, cause
 
     if group != GROUP:
         result = consts.TEST_FAILED
-        cause = "Owner group failed.  Expected {}, received {}\n".format(
-                GROUP, group)
+        cause = (
+                    'Owner group failed.  Expected {}, received {}\n'
+                    ''.format(GROUP, group)
+                )
         return result, cause
 
     tperm = utils.get_file_permissions(config, tasks_path)
     if tperm != TPERM:
         result = consts.TEST_FAILED
-        cause = "File permissions failed.  Expected {}, received {}\n".format(
-                TPERM, tperm)
+        cause = (
+                    'File permissions failed.  Expected {}, received {}\n'
+                    ''.format(TPERM, tperm)
+                )
         return result, cause
 
     return result, cause
+
 
 def teardown(config):
     os.remove(CONFIG_FILE_NAME)
@@ -110,10 +121,11 @@ def teardown(config):
         else:
             Run.run(['sudo', 'userdel', USER])
             Run.run(['sudo', 'groupdel', GROUP])
-    except:
+    except (ContainerError, RunError, ValueError):
         pass
 
     Cgroup.delete(config, CONTROLLER, CGNAME)
+
 
 def main(config):
     [result, cause] = prereqs(config)
@@ -127,6 +139,7 @@ def main(config):
         teardown(config)
 
     return [result, cause]
+
 
 if __name__ == '__main__':
     config = ftests.parse_args()

--- a/ftests/021-cgconfig-invalid_options.py
+++ b/ftests/021-cgconfig-invalid_options.py
@@ -20,12 +20,12 @@
 # along with this library; if not, see <http://www.gnu.org/licenses>.
 #
 
-from cgroup import Cgroup, CgroupVersion
+from cgroup import Cgroup
+from run import RunError
 import consts
 import ftests
-import os
-from run import RunError
 import sys
+import os
 
 CONTROLLER = 'cpuset'
 CGNAME = '021cgconfig'
@@ -33,7 +33,7 @@ CGNAME = '021cgconfig'
 CONFIG_FILE = '''group
 {} {{
     {} {{
-	cpuset.cpus = abc123;
+        cpuset.cpus = abc123;
     }}
 }}'''.format(CGNAME, CONTROLLER)
 
@@ -41,48 +41,53 @@ USER = 'cguser021'
 
 CONFIG_FILE_NAME = os.path.join(os.getcwd(), '021cgconfig.conf')
 
+
 def prereqs(config):
     result = consts.TEST_PASSED
     cause = None
 
     return result, cause
 
+
 def setup(config):
     f = open(CONFIG_FILE_NAME, 'w')
     f.write(CONFIG_FILE)
     f.close()
+
 
 def test(config):
     result = consts.TEST_PASSED
     cause = None
 
     ret = Cgroup.configparser(config, cghelp=True)
-    if not "Parse and load the specified cgroups" in ret:
+    if 'Parse and load the specified cgroups' not in ret:
         result = consts.TEST_FAILED
-        cause = "Failed to print cgconfigparser help text"
+        cause = 'Failed to print cgconfigparser help text'
         return result, cause
 
     try:
         Cgroup.configparser(config, load_file=CONFIG_FILE_NAME)
     except RunError as re:
-        if not "Invalid argument" in re.stderr:
+        if 'Invalid argument' not in re.stderr:
             result = consts.TEST_FAILED
             cause = "Expected 'Invalid argument' to be in stderr"
             return result, cause
 
         if re.ret != 96:
             result = consts.TEST_FAILED
-            cause = "Expected return code of 96 but received {}".format(re.ret)
+            cause = 'Expected return code of 96 but received {}'.format(re.ret)
             return result, cause
     else:
         result = consts.TEST_FAILED
-        cause = "Test case erroneously passed"
+        cause = 'Test case erroneously passed'
         return result, cause
 
     return result, cause
 
+
 def teardown(config):
     os.remove(CONFIG_FILE_NAME)
+
 
 def main(config):
     [result, cause] = prereqs(config)
@@ -96,6 +101,7 @@ def main(config):
         teardown(config)
 
     return [result, cause]
+
 
 if __name__ == '__main__':
     config = ftests.parse_args()

--- a/ftests/022-cgset-multiple_r_flag.py
+++ b/ftests/022-cgset-multiple_r_flag.py
@@ -23,16 +23,17 @@
 from cgroup import Cgroup, CgroupVersion
 import consts
 import ftests
-import os
 import sys
+import os
 
 CONTROLLER = 'memory'
-CGNAME = "022cgset"
+CGNAME = '022cgset'
 
 SETTINGS = ['memory.limit_in_bytes',
             'memory.soft_limit_in_bytes',
             'memory.swappiness']
 VALUES = ['1024000', '512000', '55']
+
 
 def prereqs(config):
     result = consts.TEST_PASSED
@@ -40,13 +41,15 @@ def prereqs(config):
 
     if CgroupVersion.get_version('memory') != CgroupVersion.CGROUP_V1:
         result = consts.TEST_SKIPPED
-        cause = "This test requires the cgroup v1 memory controller"
+        cause = 'This test requires the cgroup v1 memory controller'
         return result, cause
 
     return result, cause
 
+
 def setup(config):
     Cgroup.create(config, CONTROLLER, CGNAME)
+
 
 def test(config):
     Cgroup.set(config, cgname=CGNAME, setting=SETTINGS, value=VALUES)
@@ -56,8 +59,10 @@ def test(config):
 
     return consts.TEST_PASSED, None
 
+
 def teardown(config):
     Cgroup.delete(config, CONTROLLER, CGNAME)
+
 
 def main(config):
     [result, cause] = prereqs(config)
@@ -69,6 +74,7 @@ def main(config):
     teardown(config)
 
     return [result, cause]
+
 
 if __name__ == '__main__':
     config = ftests.parse_args()

--- a/ftests/023-cgset-copy_from.py
+++ b/ftests/023-cgset-copy_from.py
@@ -23,8 +23,8 @@
 from cgroup import Cgroup, CgroupVersion
 import consts
 import ftests
-import os
 import sys
+import os
 
 CONTROLLER = 'memory'
 SRC_CGNAME = '023cgsetsrc'
@@ -35,21 +35,24 @@ SETTINGS = ['memory.limit_in_bytes',
             'memory.swappiness']
 VALUES = ['122880', '40960', '42']
 
+
 def prereqs(config):
     result = consts.TEST_PASSED
     cause = None
 
     if CgroupVersion.get_version('memory') != CgroupVersion.CGROUP_V1:
         result = consts.TEST_SKIPPED
-        cause = "This test requires the cgroup v1 memory controller"
+        cause = 'This test requires the cgroup v1 memory controller'
         return result, cause
 
     return result, cause
+
 
 def setup(config):
     Cgroup.create(config, CONTROLLER, SRC_CGNAME)
     Cgroup.create(config, CONTROLLER, DST_CGNAME)
     Cgroup.set(config, cgname=SRC_CGNAME, setting=SETTINGS, value=VALUES)
+
 
 def test(config):
     Cgroup.set(config, cgname=DST_CGNAME, copy_from=SRC_CGNAME)
@@ -59,9 +62,11 @@ def test(config):
 
     return consts.TEST_PASSED, None
 
+
 def teardown(config):
     Cgroup.delete(config, CONTROLLER, SRC_CGNAME)
     Cgroup.delete(config, CONTROLLER, DST_CGNAME)
+
 
 def main(config):
     [result, cause] = prereqs(config)
@@ -73,6 +78,7 @@ def main(config):
     teardown(config)
 
     return [result, cause]
+
 
 if __name__ == '__main__':
     config = ftests.parse_args()

--- a/ftests/025-cgset-multiple_cgroups.py
+++ b/ftests/025-cgset-multiple_cgroups.py
@@ -23,15 +23,16 @@
 from cgroup import Cgroup, CgroupVersion
 import consts
 import ftests
-import os
 import sys
+import os
 
 CONTROLLER = 'memory'
-CGNAME1 = "025cgset1"
-CGNAME2 = "025gset2"
+CGNAME1 = '025cgset1'
+CGNAME2 = '025cgset2'
 
 SETTING = 'memory.swappiness'
 VALUE = '42'
+
 
 def prereqs(config):
     result = consts.TEST_PASSED
@@ -39,14 +40,16 @@ def prereqs(config):
 
     if CgroupVersion.get_version('memory') != CgroupVersion.CGROUP_V1:
         result = consts.TEST_SKIPPED
-        cause = "This test requires the cgroup v1 memory controller"
+        cause = 'This test requires the cgroup v1 memory controller'
         return result, cause
 
     return result, cause
 
+
 def setup(config):
     Cgroup.create(config, CONTROLLER, CGNAME1)
     Cgroup.create(config, CONTROLLER, CGNAME2)
+
 
 def test(config):
     Cgroup.set(config, cgname=[CGNAME1, CGNAME2], setting=SETTING, value=VALUE)
@@ -56,9 +59,11 @@ def test(config):
 
     return consts.TEST_PASSED, None
 
+
 def teardown(config):
     Cgroup.delete(config, CONTROLLER, CGNAME1)
     Cgroup.delete(config, CONTROLLER, CGNAME2)
+
 
 def main(config):
     [result, cause] = prereqs(config)
@@ -70,6 +75,7 @@ def main(config):
     teardown(config)
 
     return [result, cause]
+
 
 if __name__ == '__main__':
     config = ftests.parse_args()

--- a/ftests/026-cgset-multiple_r_multiple_cgroup.py
+++ b/ftests/026-cgset-multiple_r_multiple_cgroup.py
@@ -24,8 +24,8 @@
 from cgroup import Cgroup, CgroupVersion
 import consts
 import ftests
-import os
 import sys
+import os
 
 CONTROLLER = 'memory'
 CGNAMES = ['026cgset1', '026cgset2']
@@ -35,20 +35,23 @@ SETTINGS = ['memory.limit_in_bytes',
             'memory.swappiness']
 VALUES = ['2048000', '1024000', '89']
 
+
 def prereqs(config):
     result = consts.TEST_PASSED
     cause = None
 
     if CgroupVersion.get_version('memory') != CgroupVersion.CGROUP_V1:
         result = consts.TEST_SKIPPED
-        cause = "This test requires the cgroup v1 memory controller"
+        cause = 'This test requires the cgroup v1 memory controller'
         return result, cause
 
     return result, cause
 
+
 def setup(config):
     for cg in CGNAMES:
         Cgroup.create(config, CONTROLLER, cg)
+
 
 def test(config):
     Cgroup.set(config, cgname=CGNAMES, setting=SETTINGS, value=VALUES)
@@ -59,9 +62,11 @@ def test(config):
 
     return consts.TEST_PASSED, None
 
+
 def teardown(config):
     for cg in CGNAMES:
         Cgroup.delete(config, CONTROLLER, cg)
+
 
 def main(config):
     [result, cause] = prereqs(config)
@@ -73,6 +78,7 @@ def main(config):
     teardown(config)
 
     return [result, cause]
+
 
 if __name__ == '__main__':
     config = ftests.parse_args()

--- a/ftests/027-cgset-invalid_options.py
+++ b/ftests/027-cgset-invalid_options.py
@@ -20,16 +20,17 @@
 # along with this library; if not, see <http://www.gnu.org/licenses>.
 #
 
-from cgroup import Cgroup, CgroupVersion
+from cgroup import Cgroup
+from run import RunError
 import consts
 import ftests
-import os
-from run import RunError
 import sys
+import os
 
 CONTROLLER = 'cpu'
 CGNAME1 = '027cgset1'
 CGNAME2 = '027cgset2'
+
 
 def prereqs(config):
     result = consts.TEST_PASSED
@@ -37,9 +38,11 @@ def prereqs(config):
 
     return result, cause
 
+
 def setup(config):
     Cgroup.create(config, CONTROLLER, CGNAME1)
     Cgroup.create(config, CONTROLLER, CGNAME2)
+
 
 def test(config):
     result = consts.TEST_PASSED
@@ -47,107 +50,124 @@ def test(config):
 
     try:
         # cgset -r cpu.shares=100 --copy-from 027cgset2 027cgset1
-        Cgroup.set(config, cgname=CGNAME1, setting="cpu.shares", value="100",
+        Cgroup.set(config, cgname=CGNAME1, setting='cpu.shares', value='100',
                    copy_from=CGNAME2)
     except RunError as re:
-        if not "Wrong input parameters," in re.stderr:
+        if 'Wrong input parameters,' not in re.stderr:
             result = consts.TEST_FAILED
             cause = "#1 Expected 'Wrong input parameters' to be in stderr"
             return result, cause
 
         if re.ret != 255:
             result = consts.TEST_FAILED
-            cause = "#1 Expected return code of 255 but received {}".format(re.ret)
+            cause = (
+                        '#1 Expected return code of 255 but received {}'
+                        ''.format(re.ret)
+                    )
             return result, cause
     else:
         result = consts.TEST_FAILED
-        cause = "Test case #1 erroneously passed"
+        cause = 'Test case #1 erroneously passed'
         return result, cause
 
     try:
         # cgset -r cpu.shares=100
-        Cgroup.set(config, cgname=None, setting="cpu.shares", value="100")
+        Cgroup.set(config, cgname=None, setting='cpu.shares', value='100')
     except RunError as re:
-        if not "cgset: no cgroup specified" in re.stderr:
+        if 'cgset: no cgroup specified' not in re.stderr:
             result = consts.TEST_FAILED
             cause = "#2 Expected 'no cgroup specified' to be in stderr"
             return result, cause
 
         if re.ret != 255:
             result = consts.TEST_FAILED
-            cause = "#2 Expected return code of 255 but received {}".format(re.ret)
+            cause = (
+                        '#2 Expected return code of 255 but received {}'
+                        ''.format(re.ret)
+                    )
             return result, cause
     else:
         result = consts.TEST_FAILED
-        cause = "Test case #2 erroneously passed"
+        cause = 'Test case #2 erroneously passed'
         return result, cause
 
     try:
         # cgset 027cgset1
         Cgroup.set(config, cgname=CGNAME1)
     except RunError as re:
-        if not "cgset: no name-value pair was set" in re.stderr:
+        if 'cgset: no name-value pair was set' not in re.stderr:
             result = consts.TEST_FAILED
             cause = "#3 Expected 'no name-value pair' to be in stderr"
             return result, cause
 
         if re.ret != 255:
             result = consts.TEST_FAILED
-            cause = "#3 Expected return code of 255 but received {}".format(re.ret)
+            cause = (
+                        '#3 Expected return code of 255 but received {}'
+                        ''.format(re.ret)
+                    )
             return result, cause
     else:
         result = consts.TEST_FAILED
-        cause = "Test case #3 erroneously passed"
+        cause = 'Test case #3 erroneously passed'
         return result, cause
 
     try:
         # cgset - no flags provided
         Cgroup.set(config)
     except RunError as re:
-        if not "Usage is" in re.stderr:
+        if 'Usage is' not in re.stderr:
             result = consts.TEST_FAILED
             cause = "#4 Expected 'Usage is' to be in stderr"
             return result, cause
 
         if re.ret != 255:
             result = consts.TEST_FAILED
-            cause = "#4 Expected return code of 255 but received {}".format(re.ret)
+            cause = (
+                        '#4 Expected return code of 255 but received {}'
+                        ''.format(re.ret)
+                    )
             return result, cause
     else:
         result = consts.TEST_FAILED
-        cause = "Test case #4 erroneously passed"
+        cause = 'Test case #4 erroneously passed'
         return result, cause
 
     try:
         # cgset -r cpu.shares= 027cgset1
-        Cgroup.set(config, cgname=CGNAME1, setting="cpu.shares", value="")
+        Cgroup.set(config, cgname=CGNAME1, setting='cpu.shares', value='')
     except RunError as re:
-        if not "wrong parameter of option -r" in re.stderr:
+        if 'wrong parameter of option -r' not in re.stderr:
             result = consts.TEST_FAILED
             cause = "#5 Expected 'Wrong parameter of option' to be in stderr"
             return result, cause
 
         if re.ret != 255:
             result = consts.TEST_FAILED
-            cause = "#5 Expected return code of 255 but received {}".format(re.ret)
+            cause = (
+                        '#5 Expected return code of 255 but received {}'
+                        ''.format(re.ret)
+                    )
             return result, cause
     else:
         result = consts.TEST_FAILED
-        cause = "Test case #5 erroneously passed"
+        cause = 'Test case #5 erroneously passed'
         return result, cause
 
     # cgset -h
     ret = Cgroup.set(config, cghelp=True)
-    if not "Usage:" in ret:
+    if 'Usage:' not in ret:
         result = consts.TEST_FAILED
-        cause = "#6 Failed to print help text"
+        cause = '#6 Failed to print help text'
         return result, cause
 
     return result, cause
 
+
 def teardown(config):
     Cgroup.delete(config, CONTROLLER, CGNAME1)
     Cgroup.delete(config, CONTROLLER, CGNAME2)
+
 
 def main(config):
     [result, cause] = prereqs(config)
@@ -159,6 +179,7 @@ def main(config):
     teardown(config)
 
     return [result, cause]
+
 
 if __name__ == '__main__':
     config = ftests.parse_args()

--- a/ftests/029-lssubsys-basic_lssubsys.py
+++ b/ftests/029-lssubsys-basic_lssubsys.py
@@ -23,9 +23,9 @@
 from cgroup import Cgroup, CgroupVersion
 import consts
 import ftests
-import os
 import sys
-import utils
+import os
+
 
 def prereqs(config):
     result = consts.TEST_PASSED
@@ -33,8 +33,10 @@ def prereqs(config):
 
     return result, cause
 
+
 def setup(config):
     pass
+
 
 def test(config):
     result = consts.TEST_PASSED
@@ -49,7 +51,7 @@ def test(config):
         if mount.version == CgroupVersion.CGROUP_V2:
             continue
 
-        if mount.controller == "name=systemd" or mount.controller == "systemd":
+        if mount.controller == 'name=systemd' or mount.controller == 'systemd':
             continue
 
         found = False
@@ -66,14 +68,18 @@ def test(config):
 
         if not found:
             result = consts.TEST_FAILED
-            cause = "Failed to find {} in lssubsys list".format(
-                      mount.controller)
+            cause = (
+                        'Failed to find {} in lssubsys list'
+                        ''.format(mount.controller)
+                    )
             return result, cause
 
     return result, cause
 
+
 def teardown(config):
     pass
+
 
 def main(config):
     [result, cause] = prereqs(config)
@@ -87,6 +93,7 @@ def main(config):
         teardown(config)
 
     return [result, cause]
+
 
 if __name__ == '__main__':
     config = ftests.parse_args()

--- a/ftests/030-lssubsys-lssubsys_all.py
+++ b/ftests/030-lssubsys-lssubsys_all.py
@@ -20,12 +20,12 @@
 # along with this library; if not, see <http://www.gnu.org/licenses>.
 #
 
-from cgroup import Cgroup, CgroupVersion
+from cgroup import Cgroup
 import consts
 import ftests
-import os
 import sys
-import utils
+import os
+
 
 def prereqs(config):
     result = consts.TEST_PASSED
@@ -33,8 +33,10 @@ def prereqs(config):
 
     return result, cause
 
+
 def setup(config):
     pass
+
 
 def test(config):
     result = consts.TEST_PASSED
@@ -46,7 +48,7 @@ def test(config):
     lssubsys_list = Cgroup.lssubsys(config, ls_all=True)
 
     for mount in mount_list:
-        if mount.controller == "name=systemd" or mount.controller == "systemd":
+        if mount.controller == 'name=systemd' or mount.controller == 'systemd':
             continue
 
         found = False
@@ -61,26 +63,30 @@ def test(config):
                 found = True
                 break
 
-            if lsmount == "blkio" and mount.controller == "io":
+            if lsmount == 'blkio' and mount.controller == 'io':
                 found = True
                 break
 
         if not found:
             result = consts.TEST_FAILED
-            cause = "Failed to find {} in lssubsys list".format(
-                      mount.controller)
+            cause = (
+                        'Failed to find {} in lssubsys list'
+                        ''.format(mount.controller)
+                    )
             return result, cause
 
     ret = Cgroup.lssubsys(config, cghelp=True)
-    if not "Usage:" in ret:
+    if 'Usage:' not in ret:
         result = consts.TEST_FAILED
-        cause = "Failed to print help text"
+        cause = 'Failed to print help text'
         return result, cause
 
     return result, cause
 
+
 def teardown(config):
     pass
+
 
 def main(config):
     [result, cause] = prereqs(config)
@@ -94,6 +100,7 @@ def main(config):
         teardown(config)
 
     return [result, cause]
+
 
 if __name__ == '__main__':
     config = ftests.parse_args()

--- a/ftests/031-lscgroup-g_flag.py
+++ b/ftests/031-lscgroup-g_flag.py
@@ -23,9 +23,9 @@
 from cgroup import Cgroup, CgroupVersion
 import consts
 import ftests
-import os
-import sys
 import utils
+import sys
+import os
 
 CONTROLLER = 'cpuset'
 PARENT_CGNAME = '031lscgroup'
@@ -44,7 +44,9 @@ EXPECTED_OUT1 = '''{}:/{}/
 {}:/{}/{}
 {}:/{}/{}/{}'''.format(CONTROLLER, PARENT_CGNAME,
                        CONTROLLER, PARENT_CGNAME, CHILD_CGNAME,
-                       CONTROLLER, PARENT_CGNAME, CHILD_CGNAME, GRANDCHILD_CGNAME)
+                       CONTROLLER, PARENT_CGNAME, CHILD_CGNAME,
+                       GRANDCHILD_CGNAME)
+
 
 def prereqs(config):
     result = consts.TEST_PASSED
@@ -62,16 +64,21 @@ def prereqs(config):
         # properly list the enabled controllers for a cgroup v2 cgroup.
         # Skip this test because of this
         result = consts.TEST_SKIPPED
-        cause = "See Github Issue #50 - lscgroup lists controllers..."
+        cause = 'See Github Issue #50 - lscgroup lists controllers...'
         return result, cause
 
     return result, cause
 
+
 def setup(config):
     Cgroup.create(config, CONTROLLER, PARENT_CGNAME)
-    Cgroup.create(config, CONTROLLER, os.path.join(PARENT_CGNAME, CHILD_CGNAME))
+    Cgroup.create(
+                    config, CONTROLLER, os.path.join(
+                        PARENT_CGNAME, CHILD_CGNAME)
+                 )
     Cgroup.create(config, CONTROLLER,
                   os.path.join(PARENT_CGNAME, CHILD_CGNAME, GRANDCHILD_CGNAME))
+
 
 def test(config):
     result = consts.TEST_PASSED
@@ -80,16 +87,21 @@ def test(config):
     out = Cgroup.lscgroup(config, controller=CONTROLLER, path=PARENT_CGNAME)
     if out != EXPECTED_OUT1:
         result = consts.TEST_FAILED
-        cause = "Expected lscgroup output doesn't match received output\n" \
-                "Expected:\n{}\n" \
-                "Received:\n{}\n".format(utils.indent(EXPECTED_OUT1, 4),
-                                         utils.indent(out, 4))
+        cause = (
+                    "Expected lscgroup output doesn't match received output\n'"
+                    "Expected:\n{}\n"
+                    "Received:\n{}\n"
+                    "".format(utils.indent(EXPECTED_OUT1, 4),
+                              utils.indent(out, 4))
+                )
         return result, cause
 
     return result, cause
 
+
 def teardown(config):
     Cgroup.delete(config, CONTROLLER, PARENT_CGNAME, recursive=True)
+
 
 def main(config):
     [result, cause] = prereqs(config)
@@ -101,6 +113,7 @@ def main(config):
     teardown(config)
 
     return [result, cause]
+
 
 if __name__ == '__main__':
     config = ftests.parse_args()

--- a/ftests/032-lscgroup-multiple_g_flags.py
+++ b/ftests/032-lscgroup-multiple_g_flags.py
@@ -23,9 +23,9 @@
 from cgroup import Cgroup, CgroupVersion
 import consts
 import ftests
-import os
-import sys
 import utils
+import sys
+import os
 
 CONTROLLER = 'cpuset'
 PARENT_CGNAME = '032lscgroup'
@@ -52,6 +52,7 @@ EXPECTED_OUT1 = '''{}:/{}/
                     CONTROLLER, SIBLING_CGNAME,
                     CONTROLLER, SIBLING_CGNAME, SIBLING_CHILD_CGNAME)
 
+
 def prereqs(config):
     result = consts.TEST_PASSED
     cause = None
@@ -68,20 +69,23 @@ def prereqs(config):
         # properly list the enabled controllers for a cgroup v2 cgroup.
         # Skip this test because of this
         result = consts.TEST_SKIPPED
-        cause = "See Github Issue #50 - lscgroup lists controllers..."
+        cause = 'See Github Issue #50 - lscgroup lists controllers...'
         return result, cause
 
     return result, cause
 
+
 def setup(config):
     Cgroup.create(config, CONTROLLER, PARENT_CGNAME)
-    Cgroup.create(config, CONTROLLER, os.path.join(PARENT_CGNAME, CHILD_CGNAME))
+    Cgroup.create(config, CONTROLLER,
+                  os.path.join(PARENT_CGNAME, CHILD_CGNAME))
     Cgroup.create(config, CONTROLLER,
                   os.path.join(PARENT_CGNAME, CHILD_CGNAME, GRANDCHILD_CGNAME))
 
     Cgroup.create(config, CONTROLLER, SIBLING_CGNAME)
     Cgroup.create(config, CONTROLLER,
                   os.path.join(SIBLING_CGNAME, SIBLING_CHILD_CGNAME))
+
 
 def test(config):
     result = consts.TEST_PASSED
@@ -91,23 +95,28 @@ def test(config):
                           path=[PARENT_CGNAME, SIBLING_CGNAME])
     if out != EXPECTED_OUT1:
         result = consts.TEST_FAILED
-        cause = "Expected lscgroup output doesn't match received output\n" \
-                "Expected:\n{}\n" \
-                "Received:\n{}\n".format(utils.indent(EXPECTED_OUT1, 4),
-                                         utils.indent(out, 4))
+        cause = (
+                    "Expected lscgroup output doesn't match received output\n"
+                    "Expected:\n{}\n"
+                    "Received:\n{}\n"
+                    "".format(utils.indent(EXPECTED_OUT1, 4),
+                              utils.indent(out, 4))
+                )
         return result, cause
 
     ret = Cgroup.lscgroup(config, cghelp=True)
-    if not "Usage:" in ret:
+    if 'Usage:' not in ret:
         result = consts.TEST_FAILED
-        cause = "Failed to print help text"
+        cause = 'Failed to print help text'
         return result, cause
 
     return result, cause
 
+
 def teardown(config):
     Cgroup.delete(config, CONTROLLER, PARENT_CGNAME, recursive=True)
     Cgroup.delete(config, CONTROLLER, SIBLING_CGNAME, recursive=True)
+
 
 def main(config):
     [result, cause] = prereqs(config)
@@ -119,6 +128,7 @@ def main(config):
     teardown(config)
 
     return [result, cause]
+
 
 if __name__ == '__main__':
     config = ftests.parse_args()

--- a/ftests/033-cgget-no_flags.py
+++ b/ftests/033-cgget-no_flags.py
@@ -20,14 +20,15 @@
 # along with this library; if not, see <http://www.gnu.org/licenses>.
 #
 
-from cgroup import Cgroup, CgroupVersion
+from cgroup import Cgroup
 import consts
 import ftests
-import os
 import sys
+import os
 
 CONTROLLER = 'cpuset'
 CGNAME = '033cgget'
+
 
 def prereqs(config):
     result = consts.TEST_PASSED
@@ -35,8 +36,10 @@ def prereqs(config):
 
     return result, cause
 
+
 def setup(config):
     Cgroup.create(config, CONTROLLER, CGNAME)
+
 
 def test(config):
     result = consts.TEST_PASSED
@@ -44,20 +47,27 @@ def test(config):
 
     out = Cgroup.get(config, controller=None, cgname=CGNAME)
 
-    if out.splitlines()[0] != "{}:".format(CGNAME):
+    if out.splitlines()[0] != '{}:'.format(CGNAME):
         result = consts.TEST_FAILED
-        cause = "cgget expected the cgroup name {} in the first line.\n" \
-                "Instead it received {}".format(CGNAME, out.splitlines()[0])
+        cause = (
+                    'cgget expected the cgroup name {} in the first line.\n'
+                    'Instead it received {}'
+                    ''.format(CGNAME, out.splitlines()[0])
+                )
 
     if len(out.splitlines()) < 5:
         result = consts.TEST_FAILED
-        cause = "Too few lines output by cgget.  Received {} lines".format(
-                len(out.splitlines()))
+        cause = (
+                    'Too few lines output by cgget.  Received {} lines'
+                    ''.format(len(out.splitlines()))
+                )
 
     return result, cause
 
+
 def teardown(config):
     Cgroup.delete(config, CONTROLLER, CGNAME)
+
 
 def main(config):
     [result, cause] = prereqs(config)
@@ -69,6 +79,7 @@ def main(config):
     teardown(config)
 
     return [result, cause]
+
 
 if __name__ == '__main__':
     config = ftests.parse_args()

--- a/ftests/034-cgexec-basic_cgexec.py
+++ b/ftests/034-cgexec-basic_cgexec.py
@@ -20,29 +20,30 @@
 # along with this library; if not, see <http://www.gnu.org/licenses>.
 #
 
-from cgroup import Cgroup, CgroupVersion
+from cgroup import Cgroup
+from run import Run
 import consts
 import ftests
-import os
-from process import Process
-from run import Run
 import sys
+import os
 
-import time
 
 CONTROLLER = 'cpuset'
 CGNAME = '034cgexec'
 
+
 def prereqs(config):
     if not config.args.container:
         result = consts.TEST_SKIPPED
-        cause = "This test must be run within a container"
+        cause = 'This test must be run within a container'
         return result, cause
 
     return consts.TEST_PASSED, None
 
+
 def setup(config):
     Cgroup.create(config, CONTROLLER, CGNAME)
+
 
 def test(config):
     config.process.create_process_in_cgroup(config, CONTROLLER, CGNAME,
@@ -51,18 +52,19 @@ def test(config):
     pids = Cgroup.get_pids_in_cgroup(config, CGNAME, CONTROLLER)
     if pids is None:
         result = consts.TEST_FAILED
-        cause = "No processes were found in cgroup {}".format(CGNAME)
+        cause = 'No processes were found in cgroup {}'.format(CGNAME)
         return result, cause
 
     # run cgexec -h
     ret = Cgroup.cgexec(config, controller=CONTROLLER, cgname=CGNAME,
                         cmdline=None, cghelp=True)
-    if not "Run the task in given control group(s)" in ret:
+    if 'Run the task in given control group(s)' not in ret:
         result = consts.TEST_FAILED
-        cause = "Failed to print cgexec help text: {}".format(ret)
+        cause = 'Failed to print cgexec help text: {}'.format(ret)
         return result, cause
 
     return consts.TEST_PASSED, None
+
 
 def teardown(config):
     pids = Cgroup.get_pids_in_cgroup(config, CGNAME, CONTROLLER)
@@ -75,6 +77,7 @@ def teardown(config):
 
     Cgroup.delete(config, CONTROLLER, CGNAME)
 
+
 def main(config):
     [result, cause] = prereqs(config)
     if result != consts.TEST_PASSED:
@@ -85,6 +88,7 @@ def main(config):
     teardown(config)
 
     return [result, cause]
+
 
 if __name__ == '__main__':
     config = ftests.parse_args()

--- a/ftests/035-cgset-set_cgroup_type.py
+++ b/ftests/035-cgset-set_cgroup_type.py
@@ -23,17 +23,18 @@
 from cgroup import Cgroup, CgroupVersion
 import consts
 import ftests
-import os
 import sys
+import os
 
 # Which controller isn't all that important, but it is important that we
 # have a cgroup v2 controller
 CONTROLLER = 'cpu'
-CGNAME = "035cgset"
+CGNAME = '035cgset'
 
 SETTING = 'cgroup.type'
 BEFORE = 'domain'
 AFTER = 'threaded'
+
 
 def prereqs(config):
     result = consts.TEST_PASSED
@@ -41,14 +42,15 @@ def prereqs(config):
 
     if config.args.container:
         result = consts.TEST_SKIPPED
-        cause = "This test cannot be run within a container"
+        cause = 'This test cannot be run within a container'
         return result, cause
 
     if CgroupVersion.get_version(CONTROLLER) != CgroupVersion.CGROUP_V2:
         result = consts.TEST_SKIPPED
-        cause = "This test requires cgroup v2"
+        cause = 'This test requires cgroup v2'
 
     return result, cause
+
 
 def setup(config):
     Cgroup.create(config, CONTROLLER, CGNAME)
@@ -56,13 +58,16 @@ def setup(config):
 
     return consts.TEST_PASSED, None
 
+
 def test(config):
     Cgroup.set_and_validate(config, CGNAME, SETTING, AFTER)
 
     return consts.TEST_PASSED, None
 
+
 def teardown(config):
     Cgroup.delete(config, CONTROLLER, CGNAME)
+
 
 def main(config):
     [result, cause] = prereqs(config)
@@ -77,6 +82,7 @@ def main(config):
     teardown(config)
 
     return [result, cause]
+
 
 if __name__ == '__main__':
     config = ftests.parse_args()

--- a/ftests/036-cgset-multi_thread.py
+++ b/ftests/036-cgset-multi_thread.py
@@ -35,21 +35,23 @@ SETTING = 'cgroup.type'
 AFTER = 'threaded'
 THREADS = 3
 
+
 def prereqs(config):
     result = consts.TEST_PASSED
     cause = None
 
     if config.args.container:
         result = consts.TEST_SKIPPED
-        cause = "This test cannot be run within a container"
+        cause = 'This test cannot be run within a container'
         return result, cause
 
     if CgroupVersion.get_version(CONTROLLER) != CgroupVersion.CGROUP_V2:
         result = consts.TEST_SKIPPED
-        cause = "This test requires the cgroup v2"
+        cause = 'This test requires the cgroup v2'
         return result, cause
 
     return result, cause
+
 
 def setup(config):
     Cgroup.create(config, CONTROLLER, PARENT_CGNAME)
@@ -59,21 +61,23 @@ def setup(config):
 
     return consts.TEST_PASSED, None
 
+
 def test(config):
     config.process.create_threaded_process_in_cgroup(
                                 config, CONTROLLER, PARENT_CGNAME, THREADS)
 
     threads = Cgroup.get(config, controller=None, cgname=PARENT_CGNAME,
-                         setting="cgroup.threads", print_headers=False,
+                         setting='cgroup.threads', print_headers=False,
                          values_only=True)
     threads = threads.replace('\n', '').split('\t')
 
-    #pick the first thread
+#   #pick the first thread
     thread_tid = threads[1]
 
-    Cgroup.set_and_validate(config, CHILD_CGPATH, "cgroup.threads", thread_tid)
+    Cgroup.set_and_validate(config, CHILD_CGPATH, 'cgroup.threads', thread_tid)
 
     return consts.TEST_PASSED, None
+
 
 def teardown(config):
     # destroy the child processes
@@ -83,6 +87,7 @@ def teardown(config):
             Run.run(['sudo', 'kill', '-9', p])
 
     Cgroup.delete(config, CONTROLLER, PARENT_CGNAME, recursive=True)
+
 
 def main(config):
     [result, cause] = prereqs(config)
@@ -96,6 +101,7 @@ def main(config):
         teardown(config)
 
     return [result, cause]
+
 
 if __name__ == '__main__':
     config = ftests.parse_args()

--- a/ftests/037-cgxget-cpu_settings.py
+++ b/ftests/037-cgxget-cpu_settings.py
@@ -23,34 +23,48 @@
 from cgroup import Cgroup, CgroupVersion
 import consts
 import ftests
-import os
 import sys
+import os
 
 CONTROLLER = 'cpu'
 CGNAME = '037cgxget'
 
+CGRP_VER_V1 = CgroupVersion.CGROUP_V1
+CGRP_VER_V2 = CgroupVersion.CGROUP_V2
+
 TABLE = [
     # writesetting, writeval, writever, readsetting, readval, readver
-    ['cpu.shares', '512', CgroupVersion.CGROUP_V1, 'cpu.shares', '512', CgroupVersion.CGROUP_V1],
-    ['cpu.shares', '512', CgroupVersion.CGROUP_V1, 'cpu.weight', '50', CgroupVersion.CGROUP_V2],
+    ['cpu.shares', '512', CGRP_VER_V1, 'cpu.shares', '512', CGRP_VER_V1],
+    ['cpu.shares', '512', CGRP_VER_V1, 'cpu.weight', '50',  CGRP_VER_V2],
 
-    ['cpu.weight', '200', CgroupVersion.CGROUP_V2, 'cpu.shares', '2048', CgroupVersion.CGROUP_V1],
-    ['cpu.weight', '200', CgroupVersion.CGROUP_V2, 'cpu.weight', '200', CgroupVersion.CGROUP_V2],
+    ['cpu.weight', '200', CGRP_VER_V2, 'cpu.shares', '2048', CGRP_VER_V1],
+    ['cpu.weight', '200', CGRP_VER_V2, 'cpu.weight', '200',  CGRP_VER_V2],
 
-    ['cpu.cfs_quota_us', '10000', CgroupVersion.CGROUP_V1, 'cpu.cfs_quota_us', '10000', CgroupVersion.CGROUP_V1],
-    ['cpu.cfs_period_us', '100000', CgroupVersion.CGROUP_V1, 'cpu.cfs_period_us', '100000', CgroupVersion.CGROUP_V1],
-    ['cpu.cfs_period_us', '50000', CgroupVersion.CGROUP_V1, 'cpu.max', '10000 50000', CgroupVersion.CGROUP_V2],
+    ['cpu.cfs_quota_us',  '10000',       CGRP_VER_V1,
+     'cpu.cfs_quota_us',  '10000',       CGRP_VER_V1],
+    ['cpu.cfs_period_us', '100000',      CGRP_VER_V1,
+     'cpu.cfs_period_us', '100000',      CGRP_VER_V1],
+    ['cpu.cfs_period_us', '50000',       CGRP_VER_V1,
+     'cpu.max',           '10000 50000', CGRP_VER_V2],
 
-    ['cpu.cfs_quota_us', '-1', CgroupVersion.CGROUP_V1, 'cpu.cfs_quota_us', '-1', CgroupVersion.CGROUP_V1],
-    ['cpu.cfs_period_us', '100000', CgroupVersion.CGROUP_V1, 'cpu.max', 'max 100000', CgroupVersion.CGROUP_V2],
+    ['cpu.cfs_quota_us',  '-1',         CGRP_VER_V1,
+     'cpu.cfs_quota_us',  '-1',         CGRP_VER_V1],
+    ['cpu.cfs_period_us', '100000',     CGRP_VER_V1,
+     'cpu.max',           'max 100000', CGRP_VER_V2],
 
-    ['cpu.max', '5000 25000', CgroupVersion.CGROUP_V2, 'cpu.max', '5000 25000', CgroupVersion.CGROUP_V2],
-    ['cpu.max', '6000 26000', CgroupVersion.CGROUP_V2, 'cpu.cfs_quota_us', '6000', CgroupVersion.CGROUP_V1],
-    ['cpu.max', '7000 27000', CgroupVersion.CGROUP_V2, 'cpu.cfs_period_us', '27000', CgroupVersion.CGROUP_V1],
+    ['cpu.max',           '5000 25000', CGRP_VER_V2,
+     'cpu.max',           '5000 25000', CGRP_VER_V2],
+    ['cpu.max',           '6000 26000', CGRP_VER_V2,
+     'cpu.cfs_quota_us',  '6000',       CGRP_VER_V1],
+    ['cpu.max',           '7000 27000', CGRP_VER_V2,
+     'cpu.cfs_period_us', '27000',      CGRP_VER_V1],
 
-    ['cpu.max', 'max 40000', CgroupVersion.CGROUP_V2, 'cpu.max', 'max 40000', CgroupVersion.CGROUP_V2],
-    ['cpu.max', 'max 41000', CgroupVersion.CGROUP_V2, 'cpu.cfs_quota_us', '-1', CgroupVersion.CGROUP_V1],
+    ['cpu.max',          'max 40000', CGRP_VER_V2,
+     'cpu.max',          'max 40000', CGRP_VER_V2],
+    ['cpu.max',          'max 41000', CGRP_VER_V2,
+     'cpu.cfs_quota_us', '-1',        CGRP_VER_V1],
 ]
+
 
 def prereqs(config):
     result = consts.TEST_PASSED
@@ -58,8 +72,10 @@ def prereqs(config):
 
     return result, cause
 
+
 def setup(config):
     Cgroup.create(config, CONTROLLER, CGNAME)
+
 
 def test(config):
     result = consts.TEST_PASSED
@@ -74,14 +90,19 @@ def test(config):
                           print_headers=False)
         if out != entry[4]:
             result = consts.TEST_FAILED
-            cause = "After setting {}={}, expected {}={}, but received {}={}".format(
-                    entry[0], entry[1], entry[3], entry[4], entry[3], out)
+            cause = (
+                    'After setting {}={}, expected {}={}, but received '
+                    '{}={}'.format(entry[0], entry[1], entry[3], entry[4],
+                                   entry[3], out)
+                    )
             return result, cause
 
     return result, cause
 
+
 def teardown(config):
     Cgroup.delete(config, CONTROLLER, CGNAME)
+
 
 def main(config):
     [result, cause] = prereqs(config)
@@ -93,6 +114,7 @@ def main(config):
     teardown(config)
 
     return [result, cause]
+
 
 if __name__ == '__main__':
     config = ftests.parse_args()

--- a/ftests/038-cgxget-cpuset_settings.py
+++ b/ftests/038-cgxget-cpuset_settings.py
@@ -21,41 +21,65 @@
 #
 
 from cgroup import Cgroup, CgroupVersion
+from run import Run
 import consts
 import ftests
-import os
-from run import Run
 import sys
+import os
 
 CONTROLLER = 'cpuset'
 CGNAME = '038cgxget'
 
+CGRP_VER_V1 = CgroupVersion.CGROUP_V1
+CGRP_VER_V2 = CgroupVersion.CGROUP_V2
+
 TABLE = [
     # writesetting, writeval, writever, readsetting, readval, readver
-    ['cpuset.cpus', '0-1', CgroupVersion.CGROUP_V1, 'cpuset.cpus', '0-1', CgroupVersion.CGROUP_V1],
-    ['cpuset.cpus', '0-1', CgroupVersion.CGROUP_V1, 'cpuset.cpus', '0-1', CgroupVersion.CGROUP_V2],
-    ['cpuset.cpus', '0-1', CgroupVersion.CGROUP_V1, 'cpuset.effective_cpus', '0-1', CgroupVersion.CGROUP_V1],
-    ['cpuset.cpus', '0-1', CgroupVersion.CGROUP_V1, 'cpuset.cpus.effective', '0-1', CgroupVersion.CGROUP_V2],
-    ['cpuset.cpus', '1', CgroupVersion.CGROUP_V2, 'cpuset.cpus', '1', CgroupVersion.CGROUP_V1],
-    ['cpuset.cpus', '1', CgroupVersion.CGROUP_V2, 'cpuset.cpus', '1', CgroupVersion.CGROUP_V2],
+    ['cpuset.cpus',           '0-1', CGRP_VER_V1,
+     'cpuset.cpus',           '0-1', CGRP_VER_V1],
+    ['cpuset.cpus',           '0-1', CGRP_VER_V1,
+     'cpuset.cpus',           '0-1', CGRP_VER_V2],
+    ['cpuset.cpus',           '0-1', CGRP_VER_V1,
+     'cpuset.effective_cpus', '0-1', CGRP_VER_V1],
+    ['cpuset.cpus',           '0-1', CGRP_VER_V1,
+     'cpuset.cpus.effective', '0-1', CGRP_VER_V2],
+    ['cpuset.cpus',           '1',   CGRP_VER_V2,
+     'cpuset.cpus',           '1',   CGRP_VER_V1],
+    ['cpuset.cpus',           '1',   CGRP_VER_V2,
+     'cpuset.cpus',           '1',   CGRP_VER_V2],
 
-    ['cpuset.mems', '0', CgroupVersion.CGROUP_V1, 'cpuset.mems', '0', CgroupVersion.CGROUP_V1],
-    ['cpuset.mems', '0', CgroupVersion.CGROUP_V1, 'cpuset.mems', '0', CgroupVersion.CGROUP_V2],
-    ['cpuset.mems', '0', CgroupVersion.CGROUP_V2, 'cpuset.mems', '0', CgroupVersion.CGROUP_V1],
-    ['cpuset.mems', '0', CgroupVersion.CGROUP_V2, 'cpuset.mems', '0', CgroupVersion.CGROUP_V2],
-    ['cpuset.mems', '0', CgroupVersion.CGROUP_V1, 'cpuset.effective_mems', '0', CgroupVersion.CGROUP_V1],
-    ['cpuset.mems', '0', CgroupVersion.CGROUP_V1, 'cpuset.mems.effective', '0', CgroupVersion.CGROUP_V2],
+    ['cpuset.mems',           '0', CGRP_VER_V1,
+     'cpuset.mems',           '0', CGRP_VER_V1],
+    ['cpuset.mems',           '0', CGRP_VER_V1,
+     'cpuset.mems',           '0', CGRP_VER_V2],
+    ['cpuset.mems',           '0', CGRP_VER_V2,
+     'cpuset.mems',           '0', CGRP_VER_V1],
+    ['cpuset.mems',           '0', CGRP_VER_V2,
+     'cpuset.mems',           '0', CGRP_VER_V2],
+    ['cpuset.mems',           '0', CGRP_VER_V1,
+     'cpuset.effective_mems', '0', CGRP_VER_V1],
+    ['cpuset.mems',           '0', CGRP_VER_V1,
+     'cpuset.mems.effective', '0', CGRP_VER_V2],
 
-    ['cpuset.cpu_exclusive', '1', CgroupVersion.CGROUP_V1, 'cpuset.cpu_exclusive', '1', CgroupVersion.CGROUP_V1],
-    ['cpuset.cpu_exclusive', '1', CgroupVersion.CGROUP_V1, 'cpuset.cpus.partition', 'root', CgroupVersion.CGROUP_V2],
-    ['cpuset.cpu_exclusive', '0', CgroupVersion.CGROUP_V1, 'cpuset.cpu_exclusive', '0', CgroupVersion.CGROUP_V1],
-    ['cpuset.cpu_exclusive', '0', CgroupVersion.CGROUP_V1, 'cpuset.cpus.partition', 'member', CgroupVersion.CGROUP_V2],
+    ['cpuset.cpu_exclusive',  '1',      CGRP_VER_V1,
+     'cpuset.cpu_exclusive',  '1',      CGRP_VER_V1],
+    ['cpuset.cpu_exclusive',  '1',      CGRP_VER_V1,
+     'cpuset.cpus.partition', 'root',   CGRP_VER_V2],
+    ['cpuset.cpu_exclusive',  '0',      CGRP_VER_V1,
+     'cpuset.cpu_exclusive',  '0',      CGRP_VER_V1],
+    ['cpuset.cpu_exclusive',  '0',      CGRP_VER_V1,
+     'cpuset.cpus.partition', 'member', CGRP_VER_V2],
 
-    ['cpuset.cpus.partition', 'root', CgroupVersion.CGROUP_V2, 'cpuset.cpu_exclusive', '1', CgroupVersion.CGROUP_V1],
-    ['cpuset.cpus.partition', 'root', CgroupVersion.CGROUP_V2, 'cpuset.cpus.partition', 'root', CgroupVersion.CGROUP_V2],
-    ['cpuset.cpus.partition', 'member', CgroupVersion.CGROUP_V2, 'cpuset.cpu_exclusive', '0', CgroupVersion.CGROUP_V1],
-    ['cpuset.cpus.partition', 'member', CgroupVersion.CGROUP_V2, 'cpuset.cpus.partition', 'member', CgroupVersion.CGROUP_V2],
+    ['cpuset.cpus.partition', 'root',   CGRP_VER_V2,
+     'cpuset.cpu_exclusive',  '1',      CGRP_VER_V1],
+    ['cpuset.cpus.partition', 'root',   CGRP_VER_V2,
+     'cpuset.cpus.partition', 'root',   CGRP_VER_V2],
+    ['cpuset.cpus.partition', 'member', CGRP_VER_V2,
+     'cpuset.cpu_exclusive', '0',       CGRP_VER_V1],
+    ['cpuset.cpus.partition', 'member', CGRP_VER_V2,
+     'cpuset.cpus.partition', 'member', CGRP_VER_V2],
 ]
+
 
 def prereqs(config):
     result = consts.TEST_PASSED
@@ -64,17 +88,19 @@ def prereqs(config):
     nproc = Run.run('nproc')
     if int(nproc) < 2:
         result = consts.TEST_SKIPPED
-        cause = "This test requires 2 or more processors"
+        cause = 'This test requires 2 or more processors'
 
     if config.args.container:
         result = consts.TEST_SKIPPED
-        cause = "This test cannot be run within a container"
+        cause = 'This test cannot be run within a container'
         return result, cause
 
     return result, cause
 
+
 def setup(config):
     Cgroup.create(config, CONTROLLER, CGNAME)
+
 
 def test(config):
     result = consts.TEST_PASSED
@@ -89,14 +115,20 @@ def test(config):
                           print_headers=False)
         if out != entry[4]:
             result = consts.TEST_FAILED
-            cause = "After setting {}={}, expected {}={}, but received {}={}".format(
-                    entry[0], entry[1], entry[3], entry[4], entry[3], out)
+            cause = (
+                        'After setting {}={}, expected {}={}, but received '
+                        '{}={}'
+                        ''.format(entry[0], entry[1], entry[3], entry[4],
+                                  entry[3], out)
+                    )
             return result, cause
 
     return result, cause
 
+
 def teardown(config):
     Cgroup.delete(config, CONTROLLER, CGNAME)
+
 
 def main(config):
     [result, cause] = prereqs(config)
@@ -108,6 +140,7 @@ def main(config):
     teardown(config)
 
     return [result, cause]
+
 
 if __name__ == '__main__':
     config = ftests.parse_args()

--- a/ftests/039-pybindings-cgxget.py
+++ b/ftests/039-pybindings-cgxget.py
@@ -20,16 +20,16 @@
 # along with this library; if not, see <http://www.gnu.org/licenses>.
 #
 
-from cgroup import CgroupVersion
 from cgroup import Cgroup as CgroupCli
 from libcgroup import Cgroup, Version
+from cgroup import CgroupVersion
 import consts
 import ftests
-import os
 import sys
+import os
 
 CONTROLLER = 'cpu'
-CGNAME = "039bindings"
+CGNAME = '039bindings'
 
 SETTING1 = 'cpu.shares'
 VALUE1 = '4096'
@@ -37,10 +37,11 @@ VALUE1 = '4096'
 SETTING2 = 'cpu.weight'
 VALUE2 = '400'
 
+
 def prereqs(config):
     if config.args.container:
         result = consts.TEST_SKIPPED
-        cause = "This test cannot be run within a container"
+        cause = 'This test cannot be run within a container'
         return result, cause
 
     result = consts.TEST_PASSED
@@ -48,12 +49,14 @@ def prereqs(config):
 
     return result, cause
 
+
 def setup(config):
     CgroupCli.create(config, CONTROLLER, CGNAME)
     if CgroupVersion.get_version('cpu') == CgroupVersion.CGROUP_V1:
         CgroupCli.set(config, CGNAME, SETTING1, VALUE1)
     else:
         CgroupCli.set(config, CGNAME, SETTING2, VALUE2)
+
 
 def test(config):
     result = consts.TEST_PASSED
@@ -67,20 +70,29 @@ def test(config):
 
     if len(cg1.controllers) != 1:
         result = consts.TEST_FAILED
-        cause = "Controller length doesn't match, expected 1, but received {}".format(
-                len(cg1.controllers))
+        cause = (
+                    "Controller length doesn't match, expected 1, but "
+                    "received {}"
+                    "".format(len(cg1.controllers))
+                )
         return result, cause
 
     if len(cg1.controllers[CONTROLLER].settings) != 1:
         result = consts.TEST_FAILED
-        cause = "Settings length doesn't match, expected 1, but received {}".format(
-                len(cg1.controllers[CONTROLLER].settings))
+        cause = (
+                    "Settings length doesn't match, expected 1, but "
+                    " received {}"
+                    "".format(len(cg1.controllers[CONTROLLER].settings))
+                )
         return result, cause
 
     if cg1.controllers[CONTROLLER].settings[SETTING1] != VALUE1:
         result = consts.TEST_FAILED
-        cause = "Expected {} = {} but received {}".format(SETTING1, VALUE1,
-                cg1.controllers[CONTROLLER].settings[SETTING1])
+        cause = (
+                    'Expected {} = {} but received {}'
+                    ''.format(SETTING1, VALUE1,
+                              cg1.controllers[CONTROLLER].settings[SETTING1])
+                )
         return result, cause
 
     cg2 = Cgroup(CGNAME, Version.CGROUP_V2)
@@ -91,26 +103,37 @@ def test(config):
 
     if len(cg2.controllers) != 1:
         result = consts.TEST_FAILED
-        cause = "Controller length doesn't match, expected 1, but received {}".format(
-                len(cg2.controllers))
+        cause = (
+                    "Controller length doesn't match, expected 1, but"
+                    " received {}"
+                    "".format(len(cg2.controllers))
+                )
         return result, cause
 
     if len(cg2.controllers[CONTROLLER].settings) != 1:
         result = consts.TEST_FAILED
-        cause = "Settings length doesn't match, expected 1, but received {}".format(
-                len(cg2.controllers[CONTROLLER].settings))
+        cause = (
+                    "Settings length doesn't match, expected 1, but"
+                    "received {}"
+                    "".format(len(cg2.controllers[CONTROLLER].settings))
+                )
         return result, cause
 
     if cg2.controllers[CONTROLLER].settings[SETTING2] != VALUE2:
         result = consts.TEST_FAILED
-        cause = "Expected {} = {} but received {}".format(SETTING2, VALUE2,
-                cg2.controllers[CONTROLLER].settings[SETTING2])
+        cause = (
+                    'Expected {} = {} but received {}'
+                    ''.format(SETTING2, VALUE2,
+                              cg2.controllers[CONTROLLER].settings[SETTING2])
+                )
         return result, cause
 
     return result, cause
 
+
 def teardown(config):
     CgroupCli.delete(config, CONTROLLER, CGNAME)
+
 
 def main(config):
     [result, cause] = prereqs(config)
@@ -122,6 +145,7 @@ def main(config):
     teardown(config)
 
     return [result, cause]
+
 
 if __name__ == '__main__':
     config = ftests.parse_args()

--- a/ftests/040-pybindings-cgxset.py
+++ b/ftests/040-pybindings-cgxset.py
@@ -20,17 +20,17 @@
 # along with this library; if not, see <http://www.gnu.org/licenses>.
 #
 
-from cgroup import Cgroup as CgroupCli
 from cgroup import CgroupVersion as CgroupCliVersion
+from cgroup import Cgroup as CgroupCli
 from libcgroup import Cgroup, Version
+from run import Run
 import consts
 import ftests
-import os
-from run import Run
 import sys
+import os
 
 CONTROLLER = 'cpu'
-CGNAME = "040bindings"
+CGNAME = '040bindings'
 
 SETTING1 = 'cpu.shares'
 VALUE1 = '512'
@@ -38,10 +38,11 @@ VALUE1 = '512'
 SETTING2 = 'cpu.weight'
 VALUE2 = '50'
 
+
 def prereqs(config):
     if config.args.container:
         result = consts.TEST_SKIPPED
-        cause = "This test cannot be run within a container"
+        cause = 'This test cannot be run within a container'
         return result, cause
 
     result = consts.TEST_PASSED
@@ -49,12 +50,14 @@ def prereqs(config):
 
     return result, cause
 
+
 def setup(config):
     user_name = Run.run('whoami', shell_bool=True)
     group_name = Run.run('groups', shell_bool=True).split(' ')[0]
 
     CgroupCli.create(config, controller_list=CONTROLLER, cgname=CGNAME,
                      user_name=user_name, group_name=group_name)
+
 
 def test(config):
     result = consts.TEST_PASSED
@@ -66,18 +69,21 @@ def test(config):
 
     cg1.cgxset()
 
-    value_v1 = CgroupCli.xget(config, setting=SETTING1, print_headers=False,
-                   values_only=True, version=CgroupCliVersion.CGROUP_V1,
-                   cgname=CGNAME)
+    value_v1 = CgroupCli.xget(
+                                config, setting=SETTING1, print_headers=False,
+                                values_only=True,
+                                version=CgroupCliVersion.CGROUP_V1,
+                                cgname=CGNAME
+                             )
 
     if value_v1 != VALUE1:
         result = consts.TEST_FAILED
-        cause = "Expected {}, but received {}".format(VALUE1, value_v1)
+        cause = 'Expected {}, but received {}'.format(VALUE1, value_v1)
         return result, cause
 
     # Set the cpu.shares/cpu.weight to an arbitrary value to ensure
     # the following v2 cgxset works properly
-    CgroupCli.xset(config, cgname=CGNAME, setting=SETTING1, value="1234",
+    CgroupCli.xset(config, cgname=CGNAME, setting=SETTING1, value='1234',
                    version=CgroupCliVersion.CGROUP_V1)
 
     cg2 = Cgroup(CGNAME, Version.CGROUP_V2)
@@ -86,19 +92,24 @@ def test(config):
 
     cg2.cgxset()
 
-    value_v2 = CgroupCli.xget(config, setting=SETTING2, print_headers=False,
-                   values_only=True, version=CgroupCliVersion.CGROUP_V2,
-                   cgname=CGNAME)
+    value_v2 = CgroupCli.xget(
+                                config, setting=SETTING2, print_headers=False,
+                                values_only=True,
+                                version=CgroupCliVersion.CGROUP_V2,
+                                cgname=CGNAME
+                             )
 
     if value_v2 != VALUE2:
         result = consts.TEST_FAILED
-        cause = "Expected {}, but received {}".format(VALUE2, value_v2)
+        cause = 'Expected {}, but received {}'.format(VALUE2, value_v2)
         return result, cause
 
     return result, cause
 
+
 def teardown(config):
     CgroupCli.delete(config, CONTROLLER, CGNAME)
+
 
 def main(config):
     [result, cause] = prereqs(config)
@@ -110,6 +121,7 @@ def main(config):
     teardown(config)
 
     return [result, cause]
+
 
 if __name__ == '__main__':
     config = ftests.parse_args()

--- a/ftests/041-pybindings-library_version.py
+++ b/ftests/041-pybindings-library_version.py
@@ -23,14 +23,17 @@
 from libcgroup import Cgroup
 import consts
 import ftests
-import os
 import sys
+import os
+
 
 def prereqs(config):
     return consts.TEST_PASSED, None
 
+
 def setup(config):
     return consts.TEST_PASSED, None
+
 
 def test(config):
     result = consts.TEST_PASSED
@@ -40,23 +43,25 @@ def test(config):
 
     if not isinstance(major, int):
         result = consts.TEST_FAILED
-        cause = "Major version failed. Received {}".format(major)
+        cause = 'Major version failed. Received {}'.format(major)
         return result, cause
 
     if not isinstance(minor, int):
         result = consts.TEST_FAILED
-        cause = "Minor version failed. Received {}".format(minor)
+        cause = 'Minor version failed. Received {}'.format(minor)
         return result, cause
 
     if not isinstance(release, int):
         result = consts.TEST_FAILED
-        cause = "Release version failed. Received {}".format(release)
+        cause = 'Release version failed. Received {}'.format(release)
         return result, cause
 
     return result, cause
 
+
 def teardown(config):
     pass
+
 
 def main(config):
     [result, cause] = prereqs(config)
@@ -68,6 +73,7 @@ def main(config):
     teardown(config)
 
     return [result, cause]
+
 
 if __name__ == '__main__':
     config = ftests.parse_args()

--- a/ftests/042-cgxget-unmappable.py
+++ b/ftests/042-cgxget-unmappable.py
@@ -23,12 +23,13 @@
 from cgroup import Cgroup, CgroupVersion
 import consts
 import ftests
-import os
 import sys
+import os
 
 CONTROLLER = 'cpu'
 CGNAME = '042cgxget'
 SETTING = 'cpu.stat'
+
 
 def prereqs(config):
     result = consts.TEST_PASSED
@@ -36,8 +37,10 @@ def prereqs(config):
 
     return result, cause
 
+
 def setup(config):
     Cgroup.create(config, CONTROLLER, CGNAME)
+
 
 def test(config):
     result = consts.TEST_PASSED
@@ -49,17 +52,21 @@ def test(config):
     else:
         requested_ver = CgroupVersion.CGROUP_V1
 
-    out = Cgroup.xget(config, cgname=CGNAME, setting=SETTING,
-                      version=requested_ver, print_headers=False,
-                      ignore_unmappable=True)
+    out = Cgroup.xget(
+                        config, cgname=CGNAME, setting=SETTING,
+                        version=requested_ver, print_headers=False,
+                        ignore_unmappable=True
+                      )
     if len(out):
         result = consts.TEST_FAILED
-        cause = "Expected cgxget to return nothing.  Received {}".format(out)
+        cause = 'Expected cgxget to return nothing.  Received {}'.format(out)
 
     return result, cause
 
+
 def teardown(config):
     Cgroup.delete(config, CONTROLLER, CGNAME)
+
 
 def main(config):
     [result, cause] = prereqs(config)
@@ -71,6 +78,7 @@ def main(config):
     teardown(config)
 
     return [result, cause]
+
 
 if __name__ == '__main__':
     config = ftests.parse_args()

--- a/ftests/043-cgcreate-empty_controller.py
+++ b/ftests/043-cgcreate-empty_controller.py
@@ -23,13 +23,14 @@
 from cgroup import Cgroup, CgroupVersion
 import consts
 import ftests
-import os
 import sys
+import os
 
 # Which controller isn't all that important, but it is important that we
 # have a cgroup v2 controller
 CONTROLLER = 'cpu'
-CGNAME = "043cgcreate"
+CGNAME = '043cgcreate'
+
 
 def prereqs(config):
     result = consts.TEST_PASSED
@@ -37,12 +38,14 @@ def prereqs(config):
 
     if CgroupVersion.get_version(CONTROLLER) != CgroupVersion.CGROUP_V2:
         result = consts.TEST_SKIPPED
-        cause = "This test requires cgroup v2"
+        cause = 'This test requires cgroup v2'
 
     return result, cause
 
+
 def setup(config):
     return consts.TEST_PASSED, None
+
 
 def test(config):
     result = consts.TEST_PASSED
@@ -51,14 +54,18 @@ def test(config):
     Cgroup.create(config, None, CGNAME)
 
     # verify the cgroup exists by reading cgroup.procs
-    Cgroup.get(config, controller=None, cgname=CGNAME,
-               setting="cgroup.procs", print_headers=True,
-               values_only=False)
+    Cgroup.get(
+                config, controller=None, cgname=CGNAME,
+                setting='cgroup.procs', print_headers=True,
+                values_only=False
+              )
 
     return result, cause
 
+
 def teardown(config):
     Cgroup.delete(config, None, CGNAME)
+
 
 def main(config):
     [result, cause] = prereqs(config)
@@ -73,6 +80,7 @@ def main(config):
     teardown(config)
 
     return [result, cause]
+
 
 if __name__ == '__main__':
     config = ftests.parse_args()

--- a/ftests/044-pybindings-cgcreate_empty_controller.py
+++ b/ftests/044-pybindings-cgcreate_empty_controller.py
@@ -20,18 +20,19 @@
 # along with this library; if not, see <http://www.gnu.org/licenses>.
 #
 
-from cgroup import CgroupVersion
 from cgroup import Cgroup as CgroupCli
 from libcgroup import Cgroup, Version
+from cgroup import CgroupVersion
+from run import Run
 import consts
 import ftests
-import os
-from run import Run
 import sys
+import os
 
 CONTROLLER = 'cpu'
 PARENT_NAME = '044cgcreate'
 CGNAME = os.path.join(PARENT_NAME, 'madeviapython')
+
 
 def prereqs(config):
     result = consts.TEST_PASSED
@@ -39,14 +40,15 @@ def prereqs(config):
 
     if config.args.container:
         result = consts.TEST_SKIPPED
-        cause = "This test cannot be run within a container"
+        cause = 'This test cannot be run within a container'
         return result, cause
 
     if CgroupVersion.get_version(CONTROLLER) != CgroupVersion.CGROUP_V2:
         result = consts.TEST_SKIPPED
-        cause = "This test requires cgroup v2"
+        cause = 'This test requires cgroup v2'
 
     return result, cause
+
 
 def setup(config):
     user_name = Run.run('whoami', shell_bool=True)
@@ -54,6 +56,7 @@ def setup(config):
 
     CgroupCli.create(config, controller_list=CONTROLLER, cgname=PARENT_NAME,
                      user_name=user_name, group_name=group_name)
+
 
 def test(config):
     result = consts.TEST_PASSED
@@ -64,13 +67,15 @@ def test(config):
 
     # Read a valid file within the newly created cgroup.
     # This should fail if the cgroup was not created successfully
-    cg.add_setting(setting_name="cgroup.procs")
+    cg.add_setting(setting_name='cgroup.procs')
     cg.cgxget()
 
     return result, cause
 
+
 def teardown(config):
     CgroupCli.delete(config, None, CGNAME)
+
 
 def main(config):
     [result, cause] = prereqs(config)
@@ -82,6 +87,7 @@ def main(config):
     teardown(config)
 
     return [result, cause]
+
 
 if __name__ == '__main__':
     config = ftests.parse_args()


### PR DESCRIPTION
This is the first batch of patches, those try and make the test cases PEP8 compliant.
Along with fixing the warnings/errors reported by the `flake8` tool, it also adopts
1.  Single quotes for strings, as recommended style but again double quotes can be used if the string has a single quote as part of it instead of using `\'`.
2.  Introduces multiline using `( )` instead of '\'.
  
The warnings/errors reported across the test cases by flake8 were:

-    E101 indentation contains mixed spaces and tabs
-    E122 continuation line missing indentation or outdented
-    E128 continuation line under-indented for visual indent
-    E225 missing whitespace around operator
-    E265 block comment should start with '# '
-    E302 expected 2 blank lines, found 1
-    E305 expected 2 blank lines after class or function definition, found 1
-    E501 line too long
-    E713 test for membership should be 'not in'
-    E722 do not use bare 'except'
-    F401 imported but unused
-    W191 indentation contains tabs
-    W291 trailing whitespace

once all the warnings/errors are fixed across the source, let's introduce flake8
checks to the GitHub actions (https://github.com/marketplace/actions/flake8-action)?