### PR TITLE
Make remaining python sources PEP-8 compliant

### DIFF
--- a/ftests/config.py
+++ b/ftests/config.py
@@ -19,11 +19,12 @@
 # along with this library; if not, see <http://www.gnu.org/licenses>.
 #
 
-import consts
 from container import Container
-import os
 from process import Process
+import consts
 import utils
+import os
+
 
 class Config(object):
     def __init__(self, args, container=None):
@@ -36,8 +37,10 @@ class Config(object):
             else:
                 # Use the default container settings
                 self.container = Container(name=consts.DEFAULT_CONTAINER_NAME,
-                    stop_timeout=args.timeout, arch=None,
-                    distro=args.distro, release=args.release)
+                                           stop_timeout=args.timeout,
+                                           arch=None,
+                                           distro=args.distro,
+                                           release=args.release)
 
         self.process = Process()
 
@@ -49,19 +52,20 @@ class Config(object):
         self.verbose = False
 
     def __str__(self):
-        out_str = "Configuration\n"
+        out_str = 'Configuration\n'
         if self.args.container:
             out_str += utils.indent(str(self.container), 4)
         out_str += utils.indent(str(self.process), 4)
 
         return out_str
 
+
 class ConfigError(Exception):
     def __init__(self, message):
         super(ConfigError, self).__init__(message)
 
     def __str__(self):
-        out_str = "ConfigError:\n\tmessage = {}".format(self.message)
+        out_str = 'ConfigError:\n\tmessage = {}'.format(self.message)
         return out_str
 
 # vim: set et ts=4 sw=4:

--- a/ftests/consts.py
+++ b/ftests/consts.py
@@ -39,11 +39,11 @@ DEFAULT_CONTAINER_ARCH = 'amd64'
 DEFAULT_CONTAINER_STOP_TIMEOUT = 5
 
 TESTS_RUN_ALL = -1
-TESTS_RUN_ALL_SUITES = "allsuites"
-TEST_PASSED = "passed"
-TEST_FAILED = "failed"
-TEST_SKIPPED = "skipped"
+TESTS_RUN_ALL_SUITES = 'allsuites'
+TEST_PASSED = 'passed'
+TEST_FAILED = 'failed'
+TEST_SKIPPED = 'skipped'
 
-CGRULES_FILE = "/etc/cgrules.conf"
+CGRULES_FILE = '/etc/cgrules.conf'
 
 # vim: set et ts=4 sw=4:

--- a/ftests/container.py
+++ b/ftests/container.py
@@ -19,11 +19,10 @@
 # along with this library; if not, see <http://www.gnu.org/licenses>.
 #
 
-import consts
-import getpass
-from log import Log
-import os
 from run import Run, RunError
+import consts
+import os
+
 
 class Container(object):
     def __init__(self, name, stop_timeout=None, arch=None, cfg_path=None,
@@ -56,25 +55,23 @@ class Container(object):
         # save off the path to the libcgroup source code
         self.libcg_dir = os.path.dirname(tests_dir)
 
-
     def __str__(self):
-        out_str = "Container {}".format(self.name)
-        out_str += "\n\tdistro = {}".format(self.distro)
-        out_str += "\n\trelease = {}".format(self.release)
-        out_str += "\n\tarch = {}".format(self.arch)
-        out_str += "\n\tstop_timeout = {}\n".format(self.stop_timeout)
+        out_str = 'Container {}'.format(self.name)
+        out_str += '\n\tdistro = {}'.format(self.distro)
+        out_str += '\n\trelease = {}'.format(self.release)
+        out_str += '\n\tarch = {}'.format(self.arch)
+        out_str += '\n\tstop_timeout = {}\n'.format(self.stop_timeout)
 
         return out_str
 
     # configure the container to meet our needs
     def config(self):
-        ftest_dir = os.path.dirname(os.path.abspath(__file__))
-        tests_dir = os.path.dirname(ftest_dir)
-        libcg_dir = os.path.dirname(tests_dir)
-
         # map our UID and GID to the same UID/GID in the container
-        cmd = 'printf "uid {} 1000\ngid {} 1000" | sudo lxc config set {} raw.idmap -'.format(
-              os.getuid(), os.getgid(), self.name)
+        cmd = (
+                    'printf "uid {} 1000\ngid {} 1000" | sudo lxc config set '
+                    '{} raw.idmap -'
+                    ''.format(os.getuid(), os.getgid(), self.name)
+              )
         Run.run(cmd, shell_bool=True)
 
         # add the libcgroup root directory (where we did the build) into
@@ -87,7 +84,7 @@ class Container(object):
         cmd2.append('device')
         cmd2.append('add')
         cmd2.append(self.name)
-        cmd2.append('libcgsrc') # arbitrary name of device
+        cmd2.append('libcgsrc')  # arbitrary name of device
         cmd2.append('disk')
         # to appease gcov, mount the libcgroup source at the same path as we
         # built it.  This can be worked around someday by using
@@ -182,12 +179,13 @@ class Container(object):
 
         return Run.run(cmd)
 
+
 class ContainerError(Exception):
     def __init__(self, message, ret):
         super(RunError, self).__init__(message)
 
     def __str__(self):
-        out_str = "ContainerError:\n\tmessage = {}".format(self.message)
+        out_str = 'ContainerError:\n\tmessage = {}'.format(self.message)
         return out_str
 
 # vim: set et ts=4 sw=4:

--- a/ftests/controller.py
+++ b/ftests/controller.py
@@ -21,6 +21,7 @@
 
 from log import Log
 
+
 class Controller(object):
     # The controller class closely mirrors libcgroup's struct cgroup_controller
     def __init__(self, name):
@@ -30,10 +31,11 @@ class Controller(object):
         self.settings = dict()
 
     def __str__(self):
-        out_str = "Controller {}\n".format(self.name)
+        out_str = 'Controller {}\n'.format(self.name)
 
         for setting_key in self.settings:
-            out_str += "    {} = {}\n".format(setting_key, self.settings[setting_key])
+            out_str += '    {} = {}\n'.format(setting_key,
+                                              self.settings[setting_key])
 
         return out_str
 
@@ -51,18 +53,27 @@ class Controller(object):
             added = other_keys - self_keys
             if added is not None:
                 for key in added:
-                    Log.log_critical("Other contains {} = {}".format(key, other.settings[key]))
+                    Log.log_critical(
+                                        'Other contains {} = {}'
+                                        ''.format(key, other.settings[key])
+                                    )
 
             removed = self_keys - other_keys
             if removed is not None:
                 for key in removed:
-                    Log.log_critical("Self contains {} = {}".format(key, self.settings[key]))
+                    Log.log_critical(
+                                        'Self contains {} = {}'
+                                        ''.format(key, self.settings[key])
+                                    )
 
             common = self_keys.intersection(other_keys)
             for key in common:
                 if self.settings[key] != other.settings[key]:
-                    Log.log_critical("self{} = {} while other{} = {}".format(
-                        key, self.settings[key], key, other.settings[key]))
+                    Log.log_critical(
+                                        'self{} = {} while other{} = {}'
+                                        ''.format(key, self.settings[key],
+                                                  key, other.settings[key])
+                                    )
 
             return False
 

--- a/ftests/ftests.py
+++ b/ftests/ftests.py
@@ -20,73 +20,127 @@
 # along with this library; if not, see <http://www.gnu.org/licenses>.
 #
 
-import argparse
-from cgroup import Cgroup
 from config import Config
-import consts
-import container
-import datetime
-import log
 from log import Log
-import os
-from process import Process
 from run import Run
-import sys
+import datetime
+import argparse
+import consts
 import time
+import log
+import sys
+import os
 
 setup_time = 0.0
 teardown_time = 0.0
 
+
 def parse_args():
     parser = argparse.ArgumentParser("Libcgroup Functional Tests")
-    parser.add_argument('-n', '--name',
-                        help='name of the container',
-                        required=False, type=str, default=None)
-    parser.add_argument('-d', '--distro',
-                        help='linux distribution to use as a template',
-                        required=False, type=str, default=None)
-    parser.add_argument('-r', '--release',
-                        help='distribution release, e.g.\'trusty\'',
-                        required=False, type=str, default=None)
-    parser.add_argument('-a', '--arch',
-                        help='processor architecture',
-                        required=False, type=str, default=None)
-    parser.add_argument('-t', '--timeout',
-                        help='wait timeout (sec) before stopping the container',
-                        required=False, type=int, default=None)
+    parser.add_argument(
+                            '-n', '--name',
+                            help='name of the container',
+                            required=False,
+                            type=str,
+                            default=None
+                        )
+    parser.add_argument(
+                            '-d', '--distro',
+                            help='linux distribution to use as a template',
+                            required=False,
+                            type=str,
+                            default=None
+                        )
+    parser.add_argument(
+                            '-r', '--release',
+                            help="distribution release, e.g.'trusty'",
+                            required=False,
+                            type=str,
+                            default=None
+                        )
+    parser.add_argument(
+                            '-a', '--arch',
+                            help='processor architecture',
+                            required=False,
+                            type=str,
+                            default=None
+                        )
+    parser.add_argument(
+                            '-t', '--timeout',
+                            help='wait timeout (sec) before stopping the '
+                                 'container',
+                            required=False,
+                            type=int,
+                            default=None
+                        )
 
-    parser.add_argument('-l', '--loglevel',
-                        help='log level',
-                        required=False, type=int, default=None)
-    parser.add_argument('-L', '--logfile',
-                        help='log file',
-                        required=False, type=str, default=None)
+    parser.add_argument(
+                            '-l', '--loglevel',
+                            help='log level',
+                            required=False,
+                            type=int,
+                            default=None
+                        )
+    parser.add_argument(
+                            '-L', '--logfile',
+                            help='log file',
+                            required=False,
+                            type=str,
+                            default=None
+                        )
 
-    parser.add_argument('-N', '--num',
-                        help='Test number to run.  If unspecified, all tests are run',
-                        required=False, default=consts.TESTS_RUN_ALL, type=int)
-    parser.add_argument('-S', '--skip',
-                        help='Test number(s) to skip.  If unspecified, all tests are run.'
-                        'To skip multiple tests, separate them via a \',\', e.g. \'5,7,12\'',
-                        required=False, default='', type=str)
-    parser.add_argument('-s', '--suite',
-                        help='Test suite to run, e.g. cpuset', required=False,
-                        default=consts.TESTS_RUN_ALL_SUITES, type=str)
+    parser.add_argument(
+                            '-N', '--num',
+                            help='Test number to run.  If unspecified, all '
+                                 'tests are run',
+                            required=False,
+                            default=consts.TESTS_RUN_ALL,
+                            type=int
+                        )
+    parser.add_argument(
+                            '-S', '--skip',
+                            help="Test number(s) to skip.  If unspecified, all"
+                                 " tests are run. To skip multiple tests, "
+                                 "separate them via a ',', e.g. '5,7,12'",
+                            required=False,
+                            default='',
+                            type=str
+                        )
+    parser.add_argument(
+                            '-s', '--suite',
+                            help='Test suite to run, e.g. cpuset',
+                            required=False,
+                            default=consts.TESTS_RUN_ALL_SUITES,
+                            type=str
+                        )
 
     container_parser = parser.add_mutually_exclusive_group(required=False)
-    container_parser.add_argument('--container', action='store_true',
-                        help='Run the tests in a container. '
-                        'Note that some tests cannot be run in a container.',
-                        dest='container')
-    container_parser.add_argument('--no-container', action='store_false',
-                        help='Do not run the tests in a container. '
-                        'Note that some tests are destructive and will modify your cgroup hierarchy.',
-                        dest='container')
+    container_parser.add_argument(
+                                    '--container',
+                                    action='store_true',
+                                    help='Run the tests in a container. Note '
+                                         'that some tests cannot be run in a '
+                                         'container.',
+                                    dest='container'
+                                 )
+    container_parser.add_argument(
+                                    '--no-container',
+                                    action='store_false',
+                                    help='Do not run the tests in a container.'
+                                         ' Note that some tests are '
+                                         'destructive and will modify your '
+                                         'cgroup hierarchy.',
+                                    dest='container'
+                                 )
     parser.set_defaults(container=True)
 
-    parser.add_argument('-v', '--verbose',
-                        help='Print all information about this test run',
-                        default=True, required=False, action="store_false")
+    parser.add_argument(
+                            '-v', '--verbose',
+                            help='Print all information about this test run',
+                            default=True,
+                            required=False,
+                            action="store_false"
+                        )
 
     config = Config(parser.parse_args())
 
@@ -105,6 +159,7 @@ def parse_args():
         log.log_file = config.args.logfile
 
     return config
+
 
 # this function maps the container UID to the host UID.  By doing
 # this, we can write to a bind-mounted device - and thus generate
@@ -129,6 +184,7 @@ def update_host_subuid():
         Run.run('sudo sh -c "echo {} >> /etc/subuid"'.format(
                 subuid_line2), shell_bool=True)
 
+
 # this function maps the container GID to the host GID.  By doing
 # this, we can write to a bind-mounted device - and thus generate
 # code coverage data in the LXD container
@@ -151,6 +207,7 @@ def update_host_subgid():
     if not found_line2:
         Run.run('sudo sh -c "echo {} >> /etc/subgid"'.format(
                 subgid_line2), shell_bool=True)
+
 
 def setup(config, do_teardown=True, record_time=False):
     global setup_time
@@ -179,13 +236,19 @@ def setup(config, do_teardown=True, record_time=False):
         config.container.run(['ln', '-s', '/bin/sed', '/usr/bin/sed'])
 
         # add the libcgroup library to the container's ld
-        echo_cmd = ['bash', '-c', 'echo {} >> /etc/ld.so.conf.d/libcgroup.conf'.format(
-                   os.path.join(consts.LIBCG_MOUNT_POINT, 'src/.libs'))]
+        libcgrp_lib_path = os.path.join(consts.LIBCG_MOUNT_POINT, 'src/.libs')
+        echo_cmd = ([
+                        'bash',
+                        '-c',
+                        'echo {} >> /etc/ld.so.conf.d/libcgroup.conf'
+                        ''.format(libcgrp_lib_path)
+                    ])
         config.container.run(echo_cmd)
         config.container.run('ldconfig')
 
     if record_time:
         setup_time = time.time() - start_time
+
 
 def run_tests(config):
     passed_tests = []
@@ -205,16 +268,20 @@ def run_tests(config):
                 filenum_int = int(filenum)
             except ValueError:
                 # D'oh.  This file must not be a test.  Skip it
-                Log.log_debug('Skipping {}.  It doesn\'t start with an int'.format(
-                              filename))
+                Log.log_debug(
+                                'Skipping {}.  It doesn\'t start with an int'
+                                ''.format(filename)
+                             )
                 continue
 
             try:
                 filesuite = filename.split('-')[1]
             except IndexError:
                 Log.log_error(
-                    'Skipping {}.  It doesn\'t conform to the filename format'.format(
-                    filename))
+                                'Skipping {}.  It doesn\'t conform to the '
+                                'filename format'
+                                ''.format(filename)
+                             )
                 continue
 
             if config.args.suite == consts.TESTS_RUN_ALL_SUITES or \
@@ -251,9 +318,17 @@ def run_tests(config):
                         if ret == consts.TEST_PASSED:
                             passed_tests.append([filename, run_time])
                         elif ret == consts.TEST_FAILED:
-                            failed_tests.append([filename, run_time, failure_cause])
+                            failed_tests.append([
+                                                 filename,
+                                                 run_time,
+                                                 failure_cause
+                                                 ])
                         elif ret == consts.TEST_SKIPPED:
-                            skipped_tests.append([filename, run_time, failure_cause])
+                            skipped_tests.append([
+                                                  filename,
+                                                  run_time,
+                                                  failure_cause
+                                                  ])
                         else:
                             raise ValueError('Unexpected ret: {}'.format(ret))
 
@@ -264,37 +339,85 @@ def run_tests(config):
     print("-----------------------------------------------------------------")
     print("Test Results:")
     date_str = datetime.datetime.now().strftime('%b %d %H:%M:%S')
-    print('\t{}{}'.format('{0: <35}'.format("Run Date:"), '{0: >15}'.format(date_str)))
+    print(
+            '\t{}{}'.format(
+                                '{0: <35}'.format("Run Date:"),
+                                '{0: >15}'.format(date_str)
+                            )
+         )
 
     test_str = "{} test(s)".format(passed_cnt)
-    print('\t{}{}'.format('{0: <35}'.format("Passed:"), '{0: >15}'.format(test_str)))
+    print(
+            '\t{}{}'.format(
+                                '{0: <35}'.format("Passed:"),
+                                '{0: >15}'.format(test_str)
+                            )
+         )
 
     test_str = "{} test(s)".format(skipped_cnt)
-    print('\t{}{}'.format('{0: <35}'.format("Skipped:"), '{0: >15}'.format(test_str)))
+    print(
+            '\t{}{}'.format(
+                                '{0: <35}'.format("Skipped:"),
+                                '{0: >15}'.format(test_str)
+                            )
+         )
 
     test_str = "{} test(s)".format(failed_cnt)
-    print('\t{}{}'.format('{0: <35}'.format("Failed:"), '{0: >15}'.format(test_str)))
+    print(
+            '\t{}{}'.format(
+                                '{0: <35}'.format("Failed:"),
+                                '{0: >15}'.format(test_str)
+                            )
+         )
 
     for test in failed_tests:
-        print("\t\tTest:\t\t\t\t{} - {}".format(test[0], str(test[2])))
+        print(
+                "\t\tTest:\t\t\t\t{} - {}"
+                ''.format(test[0], str(test[2]))
+             )
     print("-----------------------------------------------------------------")
 
     global setup_time
     global teardown_time
     if config.args.verbose:
         print("Timing Results:")
-        print('\t{}{}'.format('{0: <{1}}'.format("Test", filename_max), '{0: >15}'.format("Time (sec)")))
-        print('\t{}'.format('-' * (filename_max + 15))) # 15 is padding space of "Time (sec)"
+        print(
+                '\t{}{}'.format(
+                                    '{0: <{1}}'.format("Test", filename_max),
+                                    '{0: >15}'.format("Time (sec)")
+                                )
+             )
+        print(
+                # 15 is padding space of "Time (sec)"
+                '\t{}'.format('-' * (filename_max + 15))
+             )
         time_str = "{0: 2.2f}".format(setup_time)
-        print('\t{}{}'.format('{0: <{1}}'.format('setup', filename_max), '{0: >15}'.format(time_str)))
+        print(
+                '\t{}{}'.format(
+                                    '{0: <{1}}'.format('setup', filename_max),
+                                    '{0: >15}'.format(time_str)
+                                )
+             )
 
         all_tests = passed_tests + skipped_tests + failed_tests
         all_tests.sort()
         for test in all_tests:
             time_str = "{0: 2.2f}".format(test[1])
-            print('\t{}{}'.format('{0: <{1}}'.format(test[0], filename_max), '{0: >15}'.format(time_str)))
+            print(
+                    '\t{}{}'.format(
+                                        '{0: <{1}}'.format(test[0],
+                                                           filename_max),
+                                        '{0: >15}'.format(time_str)
+                                    )
+                  )
         time_str = "{0: 2.2f}".format(teardown_time)
-        print('\t{}{}'.format('{0: <{1}}'.format('teardown', filename_max), '{0: >15}'.format(time_str)))
+        print(
+                '\t{}{}'
+                ''.format(
+                            '{0: <{1}}'.format('teardown', filename_max),
+                            '{0: >15}'.format(time_str)
+                          )
+             )
 
         total_run_time = setup_time + teardown_time
         for test in passed_tests:
@@ -303,9 +426,17 @@ def run_tests(config):
             total_run_time += test[1]
         total_str = "{0: 5.2f}".format(total_run_time)
         print('\t{}'.format('-' * (filename_max + 15)))
-        print('\t{}{}'.format('{0: <{1}}'.format("Total Run Time", filename_max), '{0: >15}'.format(total_str)))
+        print(
+                '\t{}{}'
+                ''.format(
+                            '{0: <{1}}'
+                            ''.format("Total Run Time", filename_max),
+                            '{0: >15}'.format(total_str)
+                         )
+              )
 
     return [passed_cnt, failed_cnt, skipped_cnt]
+
 
 def teardown(config, record_time=False):
     global teardown_time
@@ -328,6 +459,7 @@ def teardown(config, record_time=False):
     if record_time:
         teardown_time = time.time() - start_time
 
+
 def main(config):
     AUTOMAKE_SKIPPED = 77
     AUTOMAKE_HARD_ERROR = 99
@@ -347,6 +479,7 @@ def main(config):
         return AUTOMAKE_SKIPPED
 
     return AUTOMAKE_HARD_ERROR
+
 
 if __name__ == '__main__':
     config = parse_args()

--- a/ftests/log.py
+++ b/ftests/log.py
@@ -19,8 +19,8 @@
 # along with this library; if not, see <http://www.gnu.org/licenses>.
 #
 
-import consts
 import datetime
+import consts
 import log
 
 log_level = consts.DEFAULT_LOG_LEVEL
@@ -37,22 +37,22 @@ class Log(object):
                 Log.open_logfd(log.log_file)
 
             timestamp = datetime.datetime.now().strftime('%b %d %H:%M:%S')
-            log_fd.write("{}: {}\n".format(timestamp, msg))
+            log_fd.write('{}: {}\n'.format(timestamp, msg))
 
     @staticmethod
     def open_logfd(log_file):
-        log.log_fd = open(log_file, "a")
+        log.log_fd = open(log_file, 'a')
 
     @staticmethod
     def log_critical(msg):
-        Log.log("CRITICAL: {}".format(msg), consts.LOG_CRITICAL)
+        Log.log('CRITICAL: {}'.format(msg), consts.LOG_CRITICAL)
 
     @staticmethod
     def log_warning(msg):
-        Log.log("WARNING: {}".format(msg), consts.LOG_WARNING)
+        Log.log('WARNING: {}'.format(msg), consts.LOG_WARNING)
 
     @staticmethod
     def log_debug(msg):
-        Log.log("DEBUG: {}".format(msg), consts.LOG_DEBUG)
+        Log.log('DEBUG: {}'.format(msg), consts.LOG_DEBUG)
 
 # vim: set et ts=4 sw=4:

--- a/ftests/run.py
+++ b/ftests/run.py
@@ -21,7 +21,7 @@
 
 from log import Log
 import subprocess
-import time
+
 
 class Run(object):
     @staticmethod
@@ -46,18 +46,22 @@ class Run(object):
 
         if shell_bool:
             Log.log_debug(
-                "run:\n\tcommand = {}\n\tret = {}\n\tstdout = {}\n\tstderr = {}".format(
-                command, ret, out, err))
+                            'run:\n\tcommand = {}\n\tret = {}\n\tstdout = {}'
+                            '\n\tstderr = {}'
+                            ''.format(command, ret, out, err)
+                         )
         else:
             Log.log_debug(
-                "run:\n\tcommand = {}\n\tret = {}\n\tstdout = {}\n\tstderr = {}".format(
-                ' '.join(command), ret, out, err))
+                            'run:\n\tcommand = {}\n\tret = {}\n\tstdout = {}'
+                            '\n\tstderr = {}'
+                            ''.format(' '.join(command), ret, out, err)
+                         )
 
         if ret != 0:
             raise RunError("Command '{}' failed".format(''.join(command)),
                            command, ret, out, err)
         if ret != 0 or len(err) > 0:
-            if err.find("WARNING: cgroup v2 is not fully supported yet") == -1:
+            if err.find('WARNING: cgroup v2 is not fully supported yet') == -1:
                 # LXD throws the above warning on systems that are fully
                 # running cgroup v2.  Ignore this warning, but fail if any
                 # other warnings/errors are raised
@@ -65,6 +69,7 @@ class Run(object):
                                command, ret, out, err)
 
         return out
+
 
 class RunError(Exception):
     def __init__(self, message, command, ret, stdout, stderr):
@@ -76,9 +81,10 @@ class RunError(Exception):
         self.stderr = stderr
 
     def __str__(self):
-        out_str = "RunError:\n\tcommand = {}\n\tret = {}".format(
+        out_str = 'RunError:\n\tcommand = {}\n\tret = {}'.format(
                   self.command, self.ret)
-        out_str += "\n\tstdout = {}\n\tstderr = {}".format(self.stdout, self.stderr)
+        out_str += '\n\tstdout = {}\n\tstderr = {}'.format(self.stdout,
+                                                           self.stderr)
         return out_str
 
 # vim: set et ts=4 sw=4:

--- a/ftests/utils.py
+++ b/ftests/utils.py
@@ -19,20 +19,21 @@
 # along with this library; if not, see <http://www.gnu.org/licenses>.
 #
 
-import grp
-import os
 from run import Run
+import os
+
 
 # function to indent a block of text by cnt number of spaces
 def indent(in_str, cnt):
     leading_indent = cnt * ' '
     return ''.join(leading_indent + line for line in in_str.splitlines(True))
 
+
 def get_file_owner_uid(config, filename):
     cmd = list()
     cmd.append('stat')
     cmd.append('-c')
-    cmd.append('\'%u\'')
+    cmd.append("'%u'")
     cmd.append(filename)
 
     if config.args.container:
@@ -40,11 +41,12 @@ def get_file_owner_uid(config, filename):
     else:
         return Run.run(cmd, shell_bool=True)
 
+
 def get_file_owner_username(config, filename):
     cmd = list()
     cmd.append('stat')
     cmd.append('-c')
-    cmd.append('\'%U\'')
+    cmd.append("'%U'")
     cmd.append(filename)
 
     if config.args.container:
@@ -53,23 +55,25 @@ def get_file_owner_username(config, filename):
         return Run.run(cmd, shell_bool=True)
     return os.stat(filename).st_uid
 
+
 def get_file_owner_gid(config, filename):
     cmd = list()
     cmd.append('stat')
     cmd.append('-c')
-    cmd.append('\'%g\'')
+    cmd.append("'%g'")
     cmd.append(filename)
 
     if config.args.container:
         return config.container.run(cmd, shell_bool=True)
     else:
         return Run.run(cmd, shell_bool=True)
+
 
 def get_file_owner_group_name(config, filename):
     cmd = list()
     cmd.append('stat')
     cmd.append('-c')
-    cmd.append('\'%G\'')
+    cmd.append("'%G'")
     cmd.append(filename)
 
     if config.args.container:
@@ -77,11 +81,12 @@ def get_file_owner_group_name(config, filename):
     else:
         return Run.run(cmd, shell_bool=True)
 
+
 def get_file_permissions(config, filename):
     cmd = list()
     cmd.append('stat')
     cmd.append('-c')
-    cmd.append('\'%a\'')
+    cmd.append("'%a'")
     cmd.append(filename)
 
     if config.args.container:


### PR DESCRIPTION
This is the next batch of PEP-8 fixes. It introduces string quoting and
multiple lines, as in #36. The various PEP-8 warnings fixed across the
files are:

-   E111 indentation is not a multiple of 4
-   E117 over-indented
-   E122 continuation line missing indentation or outdented
-   E122 continuation line missing indentation or outdented
-   E122 continuation line missing indentation or outdented
-   E128 continuation line under-indented for visual indent
-   E261 at least two spaces before inline comment
-   E302 expected 2 blank lines, found 1
-   E303 too many blank lines (2)
-   E305 expected 2 blank lines after class or function definition, found 1
-   E501 line too long 
-   E502 the backslash is redundant between brackets
-   E712 comparison to False should be 'if cond is False:' or 'if not cond:'
-   E722 do not use bare 'except'
-   F401 '...' imported but unused
-   F841 local variable '...' is assigned to but never used
