### PR TITLE
run.py: fix codec type used to decode stdout, stderr

### DIFF
--- a/ftests/run.py
+++ b/ftests/run.py
@@ -41,8 +41,8 @@ class Run(object):
         out, err = subproc.communicate()
         ret = subproc.returncode
 
-        out = out.strip().decode('ascii')
-        err = err.strip().decode('ascii')
+        out = out.strip().decode('UTF-8')
+        err = err.strip().decode('UTF-8')
 
         if shell_bool:
             Log.log_debug(


### PR DESCRIPTION
Codec 'ascii' only decodes English and can't understand other characters
and raise an UnicodeDecodeError. For example, consider running 'mkdir' on
an already existing directory, it would trigger:

err.strip().decode('ascii')
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
UnicodeDecodeError: 'ascii' codec can't decode byte 0xe2 in position 31: ordinal not in range(128)

fix it by using 'UTF-8' as Codec for decoding, with the patch stderr
will be:

err.strip().decode('UTF-8')
'mkdir: cannot create directory ‘out’: File exists'

Signed-off-by: Kamalesh Babulal <kamalesh.babulal@oracle.com>