### PR TITLE
github: Run the libcgroup Github Actions

### DIFF
--- a/.github/actions/setup-libcgroup/action.yml
+++ b/.github/actions/setup-libcgroup/action.yml
@@ -1,0 +1,70 @@
+#
+# Action to setup the libcgroup directory
+#
+# Copyright (c) 2022 Oracle and/or its affiliates.
+# Author: Tom Hromatka <tom.hromatka@oracle.com>
+#
+
+#
+# This library is free software; you can redistribute it and/or modify it
+# under the terms of version 2.1 of the GNU Lesser General Public License as
+# published by the Free Software Foundation.
+#
+# This library is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License
+# for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this library; if not, see <http://www.gnu.org/licenses>.
+#
+
+name: Setup the libcgroup directory
+description: "Install dependencies, git clone, bootstrap, configure, and make libcgroup"
+runs:
+  using: "composite"
+  steps:
+  - run: sudo apt-get update
+    shell: bash
+  - run: sudo apt-get install libpam-dev lcov python3-pip python3-dev
+    shell: bash
+  - run: sudo pip install cython
+    shell: bash
+  - run: rm -fr tests/
+    shell: bash
+  - run: |
+      mkdir -p tests
+      mv Makefile.am tests/
+      mv ftests/ tests/
+      mv gunit/ tests/
+      mv .gitmodules tests/
+      mv .git tests/
+    shell: bash
+  - run: git clone https://github.com/libcgroup/libcgroup libcg
+    shell: bash
+  - run: |
+      rm -rf libcg/.github
+      rm -fr libcg/tests
+      mv libcg/* ./
+      mv libcg/.gitmodules ./
+      mv libcg/.git ./
+    shell: bash
+  - run: |
+      git submodule update --init --recursive -- googletest
+      pushd googletest/googletest
+      git checkout release-1.8.0
+      cmake -DBUILD_SHARED_LIBS=ON .
+      make
+      popd
+    shell: bash
+  - run: |
+      test -d m4 || mkdir m4
+      autoreconf -fi
+      rm -fr autom4te.cache
+    shell: bash
+  - run: CFLAGS="$CFLAGS -g -O0 -Werror" ./configure --sysconfdir=/etc --localstatedir=/var --enable-code-coverage --enable-opaque-hierarchy="name=systemd" --enable-python
+    shell: bash
+  - run: make
+    shell: bash
+  - run: lcov -i -d . -c -o lcov.base
+    shell: bash

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -28,3 +28,130 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - uses: cclauss/Find-Python-syntax-errors-action@master
+
+  # Thanks to github user @martyrs
+  # https://github.community/t/how-to-properly-clean-up-self-hosted-runners/128909/3
+  cleaner:
+    name: Delete Self-Hosted Runner Workspaces
+    runs-on: self-hosted
+    steps:
+      - name: Delete workspace path
+        run: |
+          echo "Cleaning up previous run"
+          rm -rf "${{ github.workspace }}"
+
+  unittests:
+    name: Unit Tests
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        submodules: false
+    - name: Initialize the directory
+      uses: ./.github/actions/setup-libcgroup
+    - name: Run unit tests
+      run: |
+        pushd tests/gunit
+        make check
+        popd
+    - name: Display test logs
+      if: ${{ always() }}
+      run: cat tests/gunit/test-suite.log
+
+  functionaltestsv1:
+    name: Cgroup v1 Functional Tests
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Install container dependencies
+      run: sudo apt-get install lxc lxd
+    - uses: actions/checkout@v2
+      with:
+        submodules: false
+    - name: Initialize the directory
+      uses: ./.github/actions/setup-libcgroup
+    - name: Run functional tests
+      run: |
+        # The cgroup v1 runner hosted by Github Actions doesn't allow
+        # for exclusive cpusets.  Thus, skip the cpuset automated test
+        pushd src/python/build/lib.*
+        export PYTHONPATH=$PYTHONPATH:$(pwd)
+        popd
+        pushd tests/ftests
+        ./ftests.py -l 10 -L ftests.log
+        ./ftests.py -l 10 -L ftests-nocontainer.log --skip 38 --no-container
+        popd
+
+  functionaltestsv1v2:
+    name: Cgroup v1/v2 Functional Tests
+    runs-on: ubuntu-20.04
+
+    steps:
+    - name: Mount cpuset cgroup v2 controller
+      run: |
+        # unmount the cpuset v1 controller.  This should make it available
+        # in the v2 hierarchy after all references have been freed
+        sudo umount /sys/fs/cgroup/cpuset
+        # wait for the references to the cpuset controller to go away
+        sleep 30
+        cat /sys/fs/cgroup/unified/cgroup.controllers
+        sudo su -c "echo +cpuset > /sys/fs/cgroup/unified/cgroup.subtree_control"
+        cat /sys/fs/cgroup/unified/cgroup.subtree_control
+    - name: Install container dependencies
+      run: sudo apt-get install lxc lxd
+    - uses: actions/checkout@v2
+      with:
+        submodules: false
+    - name: Initialize the directory
+      uses: ./.github/actions/setup-libcgroup
+    - name: Run functional tests
+      run: |
+        pushd src/python/build/lib.*
+        export PYTHONPATH=$PYTHONPATH:$(pwd)
+        popd
+        pushd tests/ftests
+        make check
+        popd
+    - name: Display test logs
+      if: ${{ always() }}
+      run: |
+        cat tests/ftests/ftests.sh.log
+        cat tests/ftests/ftests-nocontainer.sh.log
+    - name: Archive test logs
+      if: ${{ always() }}
+      uses: actions/upload-artifact@v2
+      with:
+        name: Cgroup v1v2 test logs
+        path: tests/ftests/*.log
+
+  functionaltestsv2:
+    name: Cgroup v2 Functional Tests
+    needs: [cleaner]
+    runs-on: self-hosted
+
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        submodules: false
+    - name: Initialize the directory
+      uses: ./.github/actions/setup-libcgroup
+    - name: Run functional tests
+      run: |
+        pushd src/python/build/lib.*
+        export PYTHONPATH=$PYTHONPATH:$(pwd)
+        popd
+        pushd tests/ftests
+        make check
+        popd
+    - name: Display test logs
+      if: ${{ always() }}
+      run: |
+        cat tests/ftests/ftests.sh.log
+        cat tests/ftests/ftests-nocontainer.sh.log
+    - name: Archive test logs
+      if: ${{ always() }}
+      uses: actions/upload-artifact@v2
+      with:
+        name: Cgroup v2 test logs
+        path: tests/ftests/*.log


### PR DESCRIPTION
Add jobs to run the libcgroup automated tests against the main
branch of libcgroup.  Since the Github Action is being
triggered from the tests repo, the setup steps differ slightly
from libcgroup's steps.  In this case we need to move the unit
and functional tests from the root to tests/, and we need to
move the library code from libcg/ to the root.

Finally, code coverage is not enabled in these runs.

`Signed-off-by: Tom Hromatka <tom.hromatka@oracle.com>`