### PR TITLE
testcases: adopt newer format of cpu.pressure

### DIFF
--- a/ftests/009-cgget-g_flag_controller_only.py
+++ b/ftests/009-cgget-g_flag_controller_only.py
@@ -55,6 +55,22 @@ cpu.uclamp.min: 0.00
 cpu.uclamp.max: max
 '''
 
+EXPECTED_OUT_V2_PSI = '''009cgget:
+cpu.weight: 100
+cpu.stat: usage_usec 0
+        user_usec 0
+        system_usec 0
+        nr_periods 0
+        nr_throttled 0
+        throttled_usec 0
+cpu.weight.nice: 0
+cpu.pressure: some avg10=0.00 avg60=0.00 avg300=0.00 total=0
+        full avg10=0.00 avg60=0.00 avg300=0.00 total=0
+cpu.max: max 100000
+cpu.uclamp.min: 0.00
+cpu.uclamp.max: max
+'''
+
 
 def prereqs(config):
     result = consts.TEST_PASSED
@@ -79,6 +95,8 @@ def test(config):
         expected_out = EXPECTED_OUT_V1
     elif version == CgroupVersion.CGROUP_V2:
         expected_out = EXPECTED_OUT_V2
+        if len(out.splitlines()) != len(expected_out.splitlines()):
+            expected_out = EXPECTED_OUT_V2_PSI
 
     if len(out.splitlines()) != len(expected_out.splitlines()):
         result = consts.TEST_FAILED

--- a/ftests/010-cgget-g_flag_controller_and_cgroup.py
+++ b/ftests/010-cgget-g_flag_controller_and_cgroup.py
@@ -53,6 +53,21 @@ cpu.uclamp.min: 0.00
 cpu.uclamp.max: max
 '''
 
+EXPECTED_OUT_V2_PSI = '''cpu.weight: 100
+cpu.stat: usage_usec 0
+        user_usec 0
+        system_usec 0
+        nr_periods 0
+        nr_throttled 0
+        throttled_usec 0
+cpu.weight.nice: 0
+cpu.pressure: some avg10=0.00 avg60=0.00 avg300=0.00 total=0
+        full avg10=0.00 avg60=0.00 avg300=0.00 total=0
+cpu.max: max 100000
+cpu.uclamp.min: 0.00
+cpu.uclamp.max: max
+'''
+
 
 def prereqs(config):
     result = consts.TEST_PASSED
@@ -78,6 +93,8 @@ def test(config):
         expected_out = EXPECTED_OUT_V1
     elif version == CgroupVersion.CGROUP_V2:
         expected_out = EXPECTED_OUT_V2
+        if len(out.splitlines()) != len(expected_out.splitlines()):
+            expected_out = EXPECTED_OUT_V2_PSI
 
     if len(out.splitlines()) != len(expected_out.splitlines()):
         result = consts.TEST_FAILED

--- a/ftests/013-cgget-multiple_g_flags.py
+++ b/ftests/013-cgget-multiple_g_flags.py
@@ -62,6 +62,25 @@ cpu.uclamp.min: 0.00
 cpu.uclamp.max: max
 '''
 
+EXPECTED_OUT_V2_PSI = '''013cgget:
+pids.current: 0
+pids.events: max 0
+pids.max: max
+cpu.weight: 100
+cpu.stat: usage_usec 0
+        user_usec 0
+        system_usec 0
+        nr_periods 0
+        nr_throttled 0
+        throttled_usec 0
+cpu.weight.nice: 0
+cpu.pressure: some avg10=0.00 avg60=0.00 avg300=0.00 total=0
+        full avg10=0.00 avg60=0.00 avg300=0.00 total=0
+cpu.max: max 100000
+cpu.uclamp.min: 0.00
+cpu.uclamp.max: max
+'''
+
 
 def prereqs(config):
     result = consts.TEST_PASSED
@@ -88,6 +107,8 @@ def test(config):
         expected_out = EXPECTED_OUT_V1
     elif version == CgroupVersion.CGROUP_V2:
         expected_out = EXPECTED_OUT_V2
+        if len(out.splitlines()) != len(expected_out.splitlines()):
+            expected_out = EXPECTED_OUT_V2_PSI
 
     if len(out.splitlines()) != len(expected_out.splitlines()):
         result = consts.TEST_FAILED


### PR DESCRIPTION
This patchset adds support to recognize the newer output of 
`cpu.pressure` on cgroup v2, which got introduced by the Kernel 
commit 0e94682b73bf ("psi: introduce psi monitor").  The newer
version of kernels with the change displays an additional line to
the existing output:
```
# cat cpu.pressure
some avg10=0.00 avg60=0.00 avg300=0.00 total=0
full avg10=0.00 avg60=0.00 avg300=0.00 total=0
```
this change in the kernel affects, multiple test cases, and each
commit fixes affected test cases individually.
