### PR TITLE
Adopt SPDX License tag

### DIFF
--- a/ftests/001-cgget-basic_cgget_v1.py
+++ b/ftests/001-cgget-basic_cgget_v1.py
@@ -1,23 +1,10 @@
 #!/usr/bin/env python3
+# SPDX-License-Identifier: LGPL-2.1-only
 #
 # Basic cgget functionality test
 #
 # Copyright (c) 2019 Oracle and/or its affiliates.  All rights reserved.
 # Author: Tom Hromatka <tom.hromatka@oracle.com>
-#
-
-#
-# This library is free software; you can redistribute it and/or modify it
-# under the terms of version 2.1 of the GNU Lesser General Public License as
-# published by the Free Software Foundation.
-#
-# This library is distributed in the hope that it will be useful, but WITHOUT
-# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
-# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License
-# for more details.
-#
-# You should have received a copy of the GNU Lesser General Public License
-# along with this library; if not, see <http://www.gnu.org/licenses>.
 #
 
 from cgroup import Cgroup, CgroupVersion

--- a/ftests/002-cgdelete-recursive_delete.py
+++ b/ftests/002-cgdelete-recursive_delete.py
@@ -1,23 +1,10 @@
 #!/usr/bin/env python3
+# SPDX-License-Identifier: LGPL-2.1-only
 #
 # Cgroup recursive cgdelete functionality test
 #
 # Copyright (c) 2020-2021 Oracle and/or its affiliates.
 # Author: Tom Hromatka <tom.hromatka@oracle.com>
-#
-
-#
-# This library is free software; you can redistribute it and/or modify it
-# under the terms of version 2.1 of the GNU Lesser General Public License as
-# published by the Free Software Foundation.
-#
-# This library is distributed in the hope that it will be useful, but WITHOUT
-# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
-# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License
-# for more details.
-#
-# You should have received a copy of the GNU Lesser General Public License
-# along with this library; if not, see <http://www.gnu.org/licenses>.
 #
 
 from cgroup import Cgroup, CgroupVersion

--- a/ftests/003-cgget-basic_cgget_v2.py
+++ b/ftests/003-cgget-basic_cgget_v2.py
@@ -1,23 +1,10 @@
 #!/usr/bin/env python3
+# SPDX-License-Identifier: LGPL-2.1-only
 #
 # Basic cgget functionality test
 #
 # Copyright (c) 2020 Oracle and/or its affiliates.
 # Author: Tom Hromatka <tom.hromatka@oracle.com>
-#
-
-#
-# This library is free software; you can redistribute it and/or modify it
-# under the terms of version 2.1 of the GNU Lesser General Public License as
-# published by the Free Software Foundation.
-#
-# This library is distributed in the hope that it will be useful, but WITHOUT
-# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
-# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License
-# for more details.
-#
-# You should have received a copy of the GNU Lesser General Public License
-# along with this library; if not, see <http://www.gnu.org/licenses>.
 #
 
 from cgroup import Cgroup, CgroupVersion

--- a/ftests/004-cgsnapshot-basic_snapshot_v1.py
+++ b/ftests/004-cgsnapshot-basic_snapshot_v1.py
@@ -1,23 +1,10 @@
 #!/usr/bin/env python3
+# SPDX-License-Identifier: LGPL-2.1-only
 #
 # Basic cgsnapshot functionality test
 #
 # Copyright (c) 2020-2021 Oracle and/or its affiliates.
 # Author: Tom Hromatka <tom.hromatka@oracle.com>
-#
-
-#
-# This library is free software; you can redistribute it and/or modify it
-# under the terms of version 2.1 of the GNU Lesser General Public License as
-# published by the Free Software Foundation.
-#
-# This library is distributed in the hope that it will be useful, but WITHOUT
-# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
-# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License
-# for more details.
-#
-# You should have received a copy of the GNU Lesser General Public License
-# along with this library; if not, see <http://www.gnu.org/licenses>.
 #
 
 from cgroup import Cgroup, CgroupVersion

--- a/ftests/005-cgsnapshot-basic_snapshot_v2.py
+++ b/ftests/005-cgsnapshot-basic_snapshot_v2.py
@@ -1,23 +1,10 @@
 #!/usr/bin/env python3
+# SPDX-License-Identifier: LGPL-2.1-only
 #
 # Basic cgsnapshot functionality test
 #
 # Copyright (c) 2020 Oracle and/or its affiliates.
 # Author: Tom Hromatka <tom.hromatka@oracle.com>
-#
-
-#
-# This library is free software; you can redistribute it and/or modify it
-# under the terms of version 2.1 of the GNU Lesser General Public License as
-# published by the Free Software Foundation.
-#
-# This library is distributed in the hope that it will be useful, but WITHOUT
-# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
-# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License
-# for more details.
-#
-# You should have received a copy of the GNU Lesser General Public License
-# along with this library; if not, see <http://www.gnu.org/licenses>.
 #
 
 from cgroup import Cgroup, CgroupVersion

--- a/ftests/006-cgrules-basic_cgrules_v1.py
+++ b/ftests/006-cgrules-basic_cgrules_v1.py
@@ -1,23 +1,10 @@
 #!/usr/bin/env python3
+# SPDX-License-Identifier: LGPL-2.1-only
 #
 # Basic cgrules functionality test
 #
 # Copyright (c) 2021 Oracle and/or its affiliates.
 # Author: Tom Hromatka <tom.hromatka@oracle.com>
-#
-
-#
-# This library is free software; you can redistribute it and/or modify it
-# under the terms of version 2.1 of the GNU Lesser General Public License as
-# published by the Free Software Foundation.
-#
-# This library is distributed in the hope that it will be useful, but WITHOUT
-# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
-# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License
-# for more details.
-#
-# You should have received a copy of the GNU Lesser General Public License
-# along with this library; if not, see <http://www.gnu.org/licenses>.
 #
 
 from cgroup import Cgroup, CgroupVersion

--- a/ftests/007-cgrules-basic_cgrules_v2.py
+++ b/ftests/007-cgrules-basic_cgrules_v2.py
@@ -1,23 +1,10 @@
 #!/usr/bin/env python3
+# SPDX-License-Identifier: LGPL-2.1-only
 #
 # Basic cgrules functionality test
 #
 # Copyright (c) 2021 Oracle and/or its affiliates.
 # Author: Tom Hromatka <tom.hromatka@oracle.com>
-#
-
-#
-# This library is free software; you can redistribute it and/or modify it
-# under the terms of version 2.1 of the GNU Lesser General Public License as
-# published by the Free Software Foundation.
-#
-# This library is distributed in the hope that it will be useful, but WITHOUT
-# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
-# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License
-# for more details.
-#
-# You should have received a copy of the GNU Lesser General Public License
-# along with this library; if not, see <http://www.gnu.org/licenses>.
 #
 
 from cgroup import Cgroup, CgroupVersion

--- a/ftests/008-cgget-multiple_r_flags.py
+++ b/ftests/008-cgget-multiple_r_flags.py
@@ -1,23 +1,10 @@
 #!/usr/bin/env python3
+# SPDX-License-Identifier: LGPL-2.1-only
 #
 # Advanced cgget functionality test - multiple '-r' flags
 #
 # Copyright (c) 2021 Oracle and/or its affiliates.
 # Author: Tom Hromatka <tom.hromatka@oracle.com>
-#
-
-#
-# This library is free software; you can redistribute it and/or modify it
-# under the terms of version 2.1 of the GNU Lesser General Public License as
-# published by the Free Software Foundation.
-#
-# This library is distributed in the hope that it will be useful, but WITHOUT
-# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
-# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License
-# for more details.
-#
-# You should have received a copy of the GNU Lesser General Public License
-# along with this library; if not, see <http://www.gnu.org/licenses>.
 #
 
 from cgroup import Cgroup, CgroupVersion

--- a/ftests/009-cgget-g_flag_controller_only.py
+++ b/ftests/009-cgget-g_flag_controller_only.py
@@ -1,23 +1,10 @@
 #!/usr/bin/env python3
+# SPDX-License-Identifier: LGPL-2.1-only
 #
 # Advanced cgget functionality test - '-g' <controller>
 #
 # Copyright (c) 2021 Oracle and/or its affiliates.
 # Author: Tom Hromatka <tom.hromatka@oracle.com>
-#
-
-#
-# This library is free software; you can redistribute it and/or modify it
-# under the terms of version 2.1 of the GNU Lesser General Public License as
-# published by the Free Software Foundation.
-#
-# This library is distributed in the hope that it will be useful, but WITHOUT
-# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
-# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License
-# for more details.
-#
-# You should have received a copy of the GNU Lesser General Public License
-# along with this library; if not, see <http://www.gnu.org/licenses>.
 #
 
 from cgroup import Cgroup, CgroupVersion

--- a/ftests/010-cgget-g_flag_controller_and_cgroup.py
+++ b/ftests/010-cgget-g_flag_controller_and_cgroup.py
@@ -1,23 +1,10 @@
 #!/usr/bin/env python3
+# SPDX-License-Identifier: LGPL-2.1-only
 #
 # Advanced cgget functionality test - '-g' <controller>:<path>
 #
 # Copyright (c) 2021 Oracle and/or its affiliates.
 # Author: Tom Hromatka <tom.hromatka@oracle.com>
-#
-
-#
-# This library is free software; you can redistribute it and/or modify it
-# under the terms of version 2.1 of the GNU Lesser General Public License as
-# published by the Free Software Foundation.
-#
-# This library is distributed in the hope that it will be useful, but WITHOUT
-# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
-# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License
-# for more details.
-#
-# You should have received a copy of the GNU Lesser General Public License
-# along with this library; if not, see <http://www.gnu.org/licenses>.
 #
 
 from cgroup import Cgroup, CgroupVersion

--- a/ftests/011-cgget-r_flag_two_cgroups.py
+++ b/ftests/011-cgget-r_flag_two_cgroups.py
@@ -1,23 +1,10 @@
 #!/usr/bin/env python3
+# SPDX-License-Identifier: LGPL-2.1-only
 #
 # Advanced cgget functionality test - '-r' <name> <cgroup1> <cgroup2>
 #
 # Copyright (c) 2021 Oracle and/or its affiliates.
 # Author: Tom Hromatka <tom.hromatka@oracle.com>
-#
-
-#
-# This library is free software; you can redistribute it and/or modify it
-# under the terms of version 2.1 of the GNU Lesser General Public License as
-# published by the Free Software Foundation.
-#
-# This library is distributed in the hope that it will be useful, but WITHOUT
-# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
-# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License
-# for more details.
-#
-# You should have received a copy of the GNU Lesser General Public License
-# along with this library; if not, see <http://www.gnu.org/licenses>.
 #
 
 from cgroup import Cgroup, CgroupVersion

--- a/ftests/012-cgget-multiple_r_flags2.py
+++ b/ftests/012-cgget-multiple_r_flags2.py
@@ -1,23 +1,10 @@
 #!/usr/bin/env python3
+# SPDX-License-Identifier: LGPL-2.1-only
 #
 # Advanced cgget functionality test - multiple '-r' flags and multiple cgroups
 #
 # Copyright (c) 2021 Oracle and/or its affiliates.
 # Author: Tom Hromatka <tom.hromatka@oracle.com>
-#
-
-#
-# This library is free software; you can redistribute it and/or modify it
-# under the terms of version 2.1 of the GNU Lesser General Public License as
-# published by the Free Software Foundation.
-#
-# This library is distributed in the hope that it will be useful, but WITHOUT
-# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
-# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License
-# for more details.
-#
-# You should have received a copy of the GNU Lesser General Public License
-# along with this library; if not, see <http://www.gnu.org/licenses>.
 #
 
 from cgroup import Cgroup, CgroupVersion

--- a/ftests/013-cgget-multiple_g_flags.py
+++ b/ftests/013-cgget-multiple_g_flags.py
@@ -1,23 +1,10 @@
 #!/usr/bin/env python3
+# SPDX-License-Identifier: LGPL-2.1-only
 #
 # Advanced cgget functionality test - multiple '-g' flags
 #
 # Copyright (c) 2021 Oracle and/or its affiliates.
 # Author: Tom Hromatka <tom.hromatka@oracle.com>
-#
-
-#
-# This library is free software; you can redistribute it and/or modify it
-# under the terms of version 2.1 of the GNU Lesser General Public License as
-# published by the Free Software Foundation.
-#
-# This library is distributed in the hope that it will be useful, but WITHOUT
-# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
-# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License
-# for more details.
-#
-# You should have received a copy of the GNU Lesser General Public License
-# along with this library; if not, see <http://www.gnu.org/licenses>.
 #
 
 from cgroup import Cgroup, CgroupVersion

--- a/ftests/014-cgget-a_flag.py
+++ b/ftests/014-cgget-a_flag.py
@@ -1,23 +1,10 @@
 #!/usr/bin/env python3
+# SPDX-License-Identifier: LGPL-2.1-only
 #
 # Advanced cgget functionality test - exercise the '-a' flag
 #
 # Copyright (c) 2021 Oracle and/or its affiliates.
 # Author: Tom Hromatka <tom.hromatka@oracle.com>
-#
-
-#
-# This library is free software; you can redistribute it and/or modify it
-# under the terms of version 2.1 of the GNU Lesser General Public License as
-# published by the Free Software Foundation.
-#
-# This library is distributed in the hope that it will be useful, but WITHOUT
-# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
-# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License
-# for more details.
-#
-# You should have received a copy of the GNU Lesser General Public License
-# along with this library; if not, see <http://www.gnu.org/licenses>.
 #
 
 from cgroup import Cgroup, CgroupVersion

--- a/ftests/015-cgget-multiline_r_flag.py
+++ b/ftests/015-cgget-multiline_r_flag.py
@@ -1,23 +1,10 @@
 #!/usr/bin/env python3
+# SPDX-License-Identifier: LGPL-2.1-only
 #
 # Advanced cgget functionality test - get a multiline value via the '-r' flag
 #
 # Copyright (c) 2021 Oracle and/or its affiliates.
 # Author: Tom Hromatka <tom.hromatka@oracle.com>
-#
-
-#
-# This library is free software; you can redistribute it and/or modify it
-# under the terms of version 2.1 of the GNU Lesser General Public License as
-# published by the Free Software Foundation.
-#
-# This library is distributed in the hope that it will be useful, but WITHOUT
-# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
-# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License
-# for more details.
-#
-# You should have received a copy of the GNU Lesser General Public License
-# along with this library; if not, see <http://www.gnu.org/licenses>.
 #
 
 from cgroup import Cgroup

--- a/ftests/016-cgget-invalid_options.py
+++ b/ftests/016-cgget-invalid_options.py
@@ -1,23 +1,10 @@
 #!/usr/bin/env python3
+# SPDX-License-Identifier: LGPL-2.1-only
 #
 # Advanced cgget functionality test - multiple '-g' flags
 #
 # Copyright (c) 2021 Oracle and/or its affiliates.
 # Author: Tom Hromatka <tom.hromatka@oracle.com>
-#
-
-#
-# This library is free software; you can redistribute it and/or modify it
-# under the terms of version 2.1 of the GNU Lesser General Public License as
-# published by the Free Software Foundation.
-#
-# This library is distributed in the hope that it will be useful, but WITHOUT
-# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
-# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License
-# for more details.
-#
-# You should have received a copy of the GNU Lesser General Public License
-# along with this library; if not, see <http://www.gnu.org/licenses>.
 #
 
 from cgroup import Cgroup

--- a/ftests/017-cgconfig-load_file.py
+++ b/ftests/017-cgconfig-load_file.py
@@ -1,23 +1,10 @@
 #!/usr/bin/env python3
+# SPDX-License-Identifier: LGPL-2.1-only
 #
 # cgconfigparser functionality test using a configuration file
 #
 # Copyright (c) 2021 Oracle and/or its affiliates.
 # Author: Tom Hromatka <tom.hromatka@oracle.com>
-#
-
-#
-# This library is free software; you can redistribute it and/or modify it
-# under the terms of version 2.1 of the GNU Lesser General Public License as
-# published by the Free Software Foundation.
-#
-# This library is distributed in the hope that it will be useful, but WITHOUT
-# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
-# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License
-# for more details.
-#
-# You should have received a copy of the GNU Lesser General Public License
-# along with this library; if not, see <http://www.gnu.org/licenses>.
 #
 
 from cgroup import Cgroup, CgroupVersion

--- a/ftests/018-cgconfig-load_dir.py
+++ b/ftests/018-cgconfig-load_dir.py
@@ -1,23 +1,10 @@
 #!/usr/bin/env python3
+# SPDX-License-Identifier: LGPL-2.1-only
 #
 # cgconfigparser functionality test using a configuration directory
 #
 # Copyright (c) 2021 Oracle and/or its affiliates.
 # Author: Tom Hromatka <tom.hromatka@oracle.com>
-#
-
-#
-# This library is free software; you can redistribute it and/or modify it
-# under the terms of version 2.1 of the GNU Lesser General Public License as
-# published by the Free Software Foundation.
-#
-# This library is distributed in the hope that it will be useful, but WITHOUT
-# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
-# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License
-# for more details.
-#
-# You should have received a copy of the GNU Lesser General Public License
-# along with this library; if not, see <http://www.gnu.org/licenses>.
 #
 
 from cgroup import Cgroup, CgroupVersion

--- a/ftests/019-cgconfig-uidgid_dperm_fperm.py
+++ b/ftests/019-cgconfig-uidgid_dperm_fperm.py
@@ -1,23 +1,10 @@
 #!/usr/bin/env python3
+# SPDX-License-Identifier: LGPL-2.1-only
 #
 # cgconfigparser functionality test - '-a', '-d', '-f' flags
 #
 # Copyright (c) 2021 Oracle and/or its affiliates.
 # Author: Tom Hromatka <tom.hromatka@oracle.com>
-#
-
-#
-# This library is free software; you can redistribute it and/or modify it
-# under the terms of version 2.1 of the GNU Lesser General Public License as
-# published by the Free Software Foundation.
-#
-# This library is distributed in the hope that it will be useful, but WITHOUT
-# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
-# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License
-# for more details.
-#
-# You should have received a copy of the GNU Lesser General Public License
-# along with this library; if not, see <http://www.gnu.org/licenses>.
 #
 
 from container import ContainerError

--- a/ftests/020-cgconfig-tasks_perms_owner.py
+++ b/ftests/020-cgconfig-tasks_perms_owner.py
@@ -1,23 +1,10 @@
 #!/usr/bin/env python3
+# SPDX-License-Identifier: LGPL-2.1-only
 #
 # cgconfigparser functionality test - '-s', '-t', flags
 #
 # Copyright (c) 2021 Oracle and/or its affiliates.
 # Author: Tom Hromatka <tom.hromatka@oracle.com>
-#
-
-#
-# This library is free software; you can redistribute it and/or modify it
-# under the terms of version 2.1 of the GNU Lesser General Public License as
-# published by the Free Software Foundation.
-#
-# This library is distributed in the hope that it will be useful, but WITHOUT
-# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
-# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License
-# for more details.
-#
-# You should have received a copy of the GNU Lesser General Public License
-# along with this library; if not, see <http://www.gnu.org/licenses>.
 #
 
 from cgroup import Cgroup, CgroupVersion

--- a/ftests/021-cgconfig-invalid_options.py
+++ b/ftests/021-cgconfig-invalid_options.py
@@ -1,23 +1,10 @@
 #!/usr/bin/env python3
+# SPDX-License-Identifier: LGPL-2.1-only
 #
 # cgconfigparser functionality test - invalid and help options
 #
 # Copyright (c) 2021 Oracle and/or its affiliates.
 # Author: Tom Hromatka <tom.hromatka@oracle.com>
-#
-
-#
-# This library is free software; you can redistribute it and/or modify it
-# under the terms of version 2.1 of the GNU Lesser General Public License as
-# published by the Free Software Foundation.
-#
-# This library is distributed in the hope that it will be useful, but WITHOUT
-# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
-# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License
-# for more details.
-#
-# You should have received a copy of the GNU Lesser General Public License
-# along with this library; if not, see <http://www.gnu.org/licenses>.
 #
 
 from cgroup import Cgroup

--- a/ftests/022-cgset-multiple_r_flag.py
+++ b/ftests/022-cgset-multiple_r_flag.py
@@ -1,23 +1,10 @@
 #!/usr/bin/env python3
+# SPDX-License-Identifier: LGPL-2.1-only
 #
 # Advanced cgset functionality test - set multiple values via the '-r' flag
 #
 # Copyright (c) 2021 Oracle and/or its affiliates.
 # Author: Tom Hromatka <tom.hromatka@oracle.com>
-#
-
-#
-# This library is free software; you can redistribute it and/or modify it
-# under the terms of version 2.1 of the GNU Lesser General Public License as
-# published by the Free Software Foundation.
-#
-# This library is distributed in the hope that it will be useful, but WITHOUT
-# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
-# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License
-# for more details.
-#
-# You should have received a copy of the GNU Lesser General Public License
-# along with this library; if not, see <http://www.gnu.org/licenses>.
 #
 
 from cgroup import Cgroup, CgroupVersion

--- a/ftests/023-cgset-copy_from.py
+++ b/ftests/023-cgset-copy_from.py
@@ -1,23 +1,10 @@
 #!/usr/bin/env python3
+# SPDX-License-Identifier: LGPL-2.1-only
 #
 # Advanced cgset functionality test - test the '--copy-from' option
 #
 # Copyright (c) 2021 Oracle and/or its affiliates.
 # Author: Tom Hromatka <tom.hromatka@oracle.com>
-#
-
-#
-# This library is free software; you can redistribute it and/or modify it
-# under the terms of version 2.1 of the GNU Lesser General Public License as
-# published by the Free Software Foundation.
-#
-# This library is distributed in the hope that it will be useful, but WITHOUT
-# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
-# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License
-# for more details.
-#
-# You should have received a copy of the GNU Lesser General Public License
-# along with this library; if not, see <http://www.gnu.org/licenses>.
 #
 
 from cgroup import Cgroup, CgroupVersion

--- a/ftests/025-cgset-multiple_cgroups.py
+++ b/ftests/025-cgset-multiple_cgroups.py
@@ -1,23 +1,10 @@
 #!/usr/bin/env python3
+# SPDX-License-Identifier: LGPL-2.1-only
 #
 # Advanced cgset functionality test - set multiple cgroups' values
 #
 # Copyright (c) 2021 Oracle and/or its affiliates.
 # Author: Tom Hromatka <tom.hromatka@oracle.com>
-#
-
-#
-# This library is free software; you can redistribute it and/or modify it
-# under the terms of version 2.1 of the GNU Lesser General Public License as
-# published by the Free Software Foundation.
-#
-# This library is distributed in the hope that it will be useful, but WITHOUT
-# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
-# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License
-# for more details.
-#
-# You should have received a copy of the GNU Lesser General Public License
-# along with this library; if not, see <http://www.gnu.org/licenses>.
 #
 
 from cgroup import Cgroup, CgroupVersion

--- a/ftests/026-cgset-multiple_r_multiple_cgroup.py
+++ b/ftests/026-cgset-multiple_r_multiple_cgroup.py
@@ -1,24 +1,11 @@
 #!/usr/bin/env python3
+# SPDX-License-Identifier: LGPL-2.1-only
 #
 # Advanced cgset functionality test - set multiple values in multiple cgroups
 #                                     via the '-r' flag
 #
 # Copyright (c) 2021 Oracle and/or its affiliates.
 # Author: Tom Hromatka <tom.hromatka@oracle.com>
-#
-
-#
-# This library is free software; you can redistribute it and/or modify it
-# under the terms of version 2.1 of the GNU Lesser General Public License as
-# published by the Free Software Foundation.
-#
-# This library is distributed in the hope that it will be useful, but WITHOUT
-# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
-# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License
-# for more details.
-#
-# You should have received a copy of the GNU Lesser General Public License
-# along with this library; if not, see <http://www.gnu.org/licenses>.
 #
 
 from cgroup import Cgroup, CgroupVersion

--- a/ftests/027-cgset-invalid_options.py
+++ b/ftests/027-cgset-invalid_options.py
@@ -1,23 +1,10 @@
 #!/usr/bin/env python3
+# SPDX-License-Identifier: LGPL-2.1-only
 #
 # Advanced cgset functionality test - invalid options
 #
 # Copyright (c) 2021 Oracle and/or its affiliates.
 # Author: Tom Hromatka <tom.hromatka@oracle.com>
-#
-
-#
-# This library is free software; you can redistribute it and/or modify it
-# under the terms of version 2.1 of the GNU Lesser General Public License as
-# published by the Free Software Foundation.
-#
-# This library is distributed in the hope that it will be useful, but WITHOUT
-# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
-# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License
-# for more details.
-#
-# You should have received a copy of the GNU Lesser General Public License
-# along with this library; if not, see <http://www.gnu.org/licenses>.
 #
 
 from cgroup import Cgroup

--- a/ftests/029-lssubsys-basic_lssubsys.py
+++ b/ftests/029-lssubsys-basic_lssubsys.py
@@ -1,23 +1,10 @@
 #!/usr/bin/env python3
+# SPDX-License-Identifier: LGPL-2.1-only
 #
 # Basic lssubsys functionality test
 #
 # Copyright (c) 2021 Oracle and/or its affiliates.
 # Author: Tom Hromatka <tom.hromatka@oracle.com>
-#
-
-#
-# This library is free software; you can redistribute it and/or modify it
-# under the terms of version 2.1 of the GNU Lesser General Public License as
-# published by the Free Software Foundation.
-#
-# This library is distributed in the hope that it will be useful, but WITHOUT
-# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
-# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License
-# for more details.
-#
-# You should have received a copy of the GNU Lesser General Public License
-# along with this library; if not, see <http://www.gnu.org/licenses>.
 #
 
 from cgroup import Cgroup, CgroupVersion

--- a/ftests/030-lssubsys-lssubsys_all.py
+++ b/ftests/030-lssubsys-lssubsys_all.py
@@ -1,23 +1,10 @@
 #!/usr/bin/env python3
+# SPDX-License-Identifier: LGPL-2.1-only
 #
 # 'lssubsys -a' test
 #
 # Copyright (c) 2021 Oracle and/or its affiliates.
 # Author: Tom Hromatka <tom.hromatka@oracle.com>
-#
-
-#
-# This library is free software; you can redistribute it and/or modify it
-# under the terms of version 2.1 of the GNU Lesser General Public License as
-# published by the Free Software Foundation.
-#
-# This library is distributed in the hope that it will be useful, but WITHOUT
-# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
-# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License
-# for more details.
-#
-# You should have received a copy of the GNU Lesser General Public License
-# along with this library; if not, see <http://www.gnu.org/licenses>.
 #
 
 from cgroup import Cgroup

--- a/ftests/031-lscgroup-g_flag.py
+++ b/ftests/031-lscgroup-g_flag.py
@@ -1,23 +1,10 @@
 #!/usr/bin/env python3
+# SPDX-License-Identifier: LGPL-2.1-only
 #
 # lscgroup functionality test
 #
 # Copyright (c) 2021 Oracle and/or its affiliates.
 # Author: Tom Hromatka <tom.hromatka@oracle.com>
-#
-
-#
-# This library is free software; you can redistribute it and/or modify it
-# under the terms of version 2.1 of the GNU Lesser General Public License as
-# published by the Free Software Foundation.
-#
-# This library is distributed in the hope that it will be useful, but WITHOUT
-# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
-# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License
-# for more details.
-#
-# You should have received a copy of the GNU Lesser General Public License
-# along with this library; if not, see <http://www.gnu.org/licenses>.
 #
 
 from cgroup import Cgroup, CgroupVersion

--- a/ftests/032-lscgroup-multiple_g_flags.py
+++ b/ftests/032-lscgroup-multiple_g_flags.py
@@ -1,23 +1,10 @@
 #!/usr/bin/env python3
+# SPDX-License-Identifier: LGPL-2.1-only
 #
 # lscgroup functionality test - multiple '-g' flags
 #
 # Copyright (c) 2021 Oracle and/or its affiliates.
 # Author: Tom Hromatka <tom.hromatka@oracle.com>
-#
-
-#
-# This library is free software; you can redistribute it and/or modify it
-# under the terms of version 2.1 of the GNU Lesser General Public License as
-# published by the Free Software Foundation.
-#
-# This library is distributed in the hope that it will be useful, but WITHOUT
-# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
-# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License
-# for more details.
-#
-# You should have received a copy of the GNU Lesser General Public License
-# along with this library; if not, see <http://www.gnu.org/licenses>.
 #
 
 from cgroup import Cgroup, CgroupVersion

--- a/ftests/033-cgget-no_flags.py
+++ b/ftests/033-cgget-no_flags.py
@@ -1,23 +1,10 @@
 #!/usr/bin/env python3
+# SPDX-License-Identifier: LGPL-2.1-only
 #
 # Advanced cgget functionality test - no flags, only a cgroup
 #
 # Copyright (c) 2021 Oracle and/or its affiliates.
 # Author: Tom Hromatka <tom.hromatka@oracle.com>
-#
-
-#
-# This library is free software; you can redistribute it and/or modify it
-# under the terms of version 2.1 of the GNU Lesser General Public License as
-# published by the Free Software Foundation.
-#
-# This library is distributed in the hope that it will be useful, but WITHOUT
-# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
-# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License
-# for more details.
-#
-# You should have received a copy of the GNU Lesser General Public License
-# along with this library; if not, see <http://www.gnu.org/licenses>.
 #
 
 from cgroup import Cgroup

--- a/ftests/034-cgexec-basic_cgexec.py
+++ b/ftests/034-cgexec-basic_cgexec.py
@@ -1,23 +1,10 @@
 #!/usr/bin/env python3
+# SPDX-License-Identifier: LGPL-2.1-only
 #
 # Cgroup cgexec test
 #
 # Copyright (c) 2021 Oracle and/or its affiliates.
 # Author: Tom Hromatka <tom.hromatka@oracle.com>
-#
-
-#
-# This library is free software; you can redistribute it and/or modify it
-# under the terms of version 2.1 of the GNU Lesser General Public License as
-# published by the Free Software Foundation.
-#
-# This library is distributed in the hope that it will be useful, but WITHOUT
-# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
-# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License
-# for more details.
-#
-# You should have received a copy of the GNU Lesser General Public License
-# along with this library; if not, see <http://www.gnu.org/licenses>.
 #
 
 from cgroup import Cgroup

--- a/ftests/035-cgset-set_cgroup_type.py
+++ b/ftests/035-cgset-set_cgroup_type.py
@@ -1,23 +1,10 @@
 #!/usr/bin/env python3
+# SPDX-License-Identifier: LGPL-2.1-only
 #
 # cgget/cgset cgroup.type functionality test
 #
 # Copyright (c) 2021 Oracle and/or its affiliates.
 # Author: Tom Hromatka <tom.hromatka@oracle.com>
-#
-
-#
-# This library is free software; you can redistribute it and/or modify it
-# under the terms of version 2.1 of the GNU Lesser General Public License as
-# published by the Free Software Foundation.
-#
-# This library is distributed in the hope that it will be useful, but WITHOUT
-# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
-# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License
-# for more details.
-#
-# You should have received a copy of the GNU Lesser General Public License
-# along with this library; if not, see <http://www.gnu.org/licenses>.
 #
 
 from cgroup import Cgroup, CgroupVersion

--- a/ftests/036-cgset-multi_thread.py
+++ b/ftests/036-cgset-multi_thread.py
@@ -1,23 +1,10 @@
 #!/usr/bin/env python3
+# SPDX-License-Identifier: LGPL-2.1-only
 #
 # Multithreaded cgroup v2 test
 #
 # Copyright (c) 2022 Oracle and/or its affiliates.
 # Author: Kamalesh Babulal <kamalesh.babulal@oracle.com>
-#
-
-#
-# This library is free software; you can redistribute it and/or modify it
-# under the terms of version 2.1 of the GNU Lesser General Public License as
-# published by the Free Software Foundation.
-#
-# This library is distributed in the hope that it will be useful, but WITHOUT
-# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
-# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License
-# for more details.
-#
-# You should have received a copy of the GNU Lesser General Public License
-# along with this library; if not, see <http://www.gnu.org/licenses>.
 #
 
 from cgroup import Cgroup, CgroupVersion

--- a/ftests/037-cgxget-cpu_settings.py
+++ b/ftests/037-cgxget-cpu_settings.py
@@ -1,23 +1,10 @@
 #!/usr/bin/env python3
+# SPDX-License-Identifier: LGPL-2.1-only
 #
 # cgxget functionality test - various cpu settings
 #
 # Copyright (c) 2021-2022 Oracle and/or its affiliates.
 # Author: Tom Hromatka <tom.hromatka@oracle.com>
-#
-
-#
-# This library is free software; you can redistribute it and/or modify it
-# under the terms of version 2.1 of the GNU Lesser General Public License as
-# published by the Free Software Foundation.
-#
-# This library is distributed in the hope that it will be useful, but WITHOUT
-# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
-# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License
-# for more details.
-#
-# You should have received a copy of the GNU Lesser General Public License
-# along with this library; if not, see <http://www.gnu.org/licenses>.
 #
 
 from cgroup import Cgroup, CgroupVersion

--- a/ftests/038-cgxget-cpuset_settings.py
+++ b/ftests/038-cgxget-cpuset_settings.py
@@ -1,23 +1,10 @@
 #!/usr/bin/env python3
+# SPDX-License-Identifier: LGPL-2.1-only
 #
 # cgxget functionality test - various cpuset settings
 #
 # Copyright (c) 2021-2022 Oracle and/or its affiliates.
 # Author: Tom Hromatka <tom.hromatka@oracle.com>
-#
-
-#
-# This library is free software; you can redistribute it and/or modify it
-# under the terms of version 2.1 of the GNU Lesser General Public License as
-# published by the Free Software Foundation.
-#
-# This library is distributed in the hope that it will be useful, but WITHOUT
-# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
-# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License
-# for more details.
-#
-# You should have received a copy of the GNU Lesser General Public License
-# along with this library; if not, see <http://www.gnu.org/licenses>.
 #
 
 from cgroup import Cgroup, CgroupVersion

--- a/ftests/039-pybindings-cgxget.py
+++ b/ftests/039-pybindings-cgxget.py
@@ -1,23 +1,10 @@
 #!/usr/bin/env python3
+# SPDX-License-Identifier: LGPL-2.1-only
 #
 # cgxget functionality test using the python bindings
 #
 # Copyright (c) 2021-2022 Oracle and/or its affiliates.
 # Author: Tom Hromatka <tom.hromatka@oracle.com>
-#
-
-#
-# This library is free software; you can redistribute it and/or modify it
-# under the terms of version 2.1 of the GNU Lesser General Public License as
-# published by the Free Software Foundation.
-#
-# This library is distributed in the hope that it will be useful, but WITHOUT
-# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
-# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License
-# for more details.
-#
-# You should have received a copy of the GNU Lesser General Public License
-# along with this library; if not, see <http://www.gnu.org/licenses>.
 #
 
 from cgroup import Cgroup as CgroupCli

--- a/ftests/040-pybindings-cgxset.py
+++ b/ftests/040-pybindings-cgxset.py
@@ -1,23 +1,10 @@
 #!/usr/bin/env python3
+# SPDX-License-Identifier: LGPL-2.1-only
 #
 # cgxset functionality test using the python bindings
 #
 # Copyright (c) 2021-2022 Oracle and/or its affiliates.
 # Author: Tom Hromatka <tom.hromatka@oracle.com>
-#
-
-#
-# This library is free software; you can redistribute it and/or modify it
-# under the terms of version 2.1 of the GNU Lesser General Public License as
-# published by the Free Software Foundation.
-#
-# This library is distributed in the hope that it will be useful, but WITHOUT
-# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
-# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License
-# for more details.
-#
-# You should have received a copy of the GNU Lesser General Public License
-# along with this library; if not, see <http://www.gnu.org/licenses>.
 #
 
 from cgroup import CgroupVersion as CgroupCliVersion

--- a/ftests/041-pybindings-library_version.py
+++ b/ftests/041-pybindings-library_version.py
@@ -1,23 +1,10 @@
 #!/usr/bin/env python3
+# SPDX-License-Identifier: LGPL-2.1-only
 #
 # get the library version using the python bindings
 #
 # Copyright (c) 2021-2022 Oracle and/or its affiliates.
 # Author: Tom Hromatka <tom.hromatka@oracle.com>
-#
-
-#
-# This library is free software; you can redistribute it and/or modify it
-# under the terms of version 2.1 of the GNU Lesser General Public License as
-# published by the Free Software Foundation.
-#
-# This library is distributed in the hope that it will be useful, but WITHOUT
-# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
-# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License
-# for more details.
-#
-# You should have received a copy of the GNU Lesser General Public License
-# along with this library; if not, see <http://www.gnu.org/licenses>.
 #
 
 from libcgroup import Cgroup

--- a/ftests/042-cgxget-unmappable.py
+++ b/ftests/042-cgxget-unmappable.py
@@ -1,23 +1,10 @@
 #!/usr/bin/env python3
+# SPDX-License-Identifier: LGPL-2.1-only
 #
 # Cgxget test with no mappable settings
 #
 # Copyright (c) 2022 Oracle and/or its affiliates.
 # Author: Tom Hromatka <tom.hromatka@oracle.com>
-#
-
-#
-# This library is free software; you can redistribute it and/or modify it
-# under the terms of version 2.1 of the GNU Lesser General Public License as
-# published by the Free Software Foundation.
-#
-# This library is distributed in the hope that it will be useful, but WITHOUT
-# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
-# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License
-# for more details.
-#
-# You should have received a copy of the GNU Lesser General Public License
-# along with this library; if not, see <http://www.gnu.org/licenses>.
 #
 
 from cgroup import Cgroup, CgroupVersion

--- a/ftests/043-cgcreate-empty_controller.py
+++ b/ftests/043-cgcreate-empty_controller.py
@@ -1,23 +1,10 @@
 #!/usr/bin/env python3
+# SPDX-License-Identifier: LGPL-2.1-only
 #
 # cgcreate with no controller specified functionality test
 #
 # Copyright (c) 2021-2022 Oracle and/or its affiliates.
 # Author: Tom Hromatka <tom.hromatka@oracle.com>
-#
-
-#
-# This library is free software; you can redistribute it and/or modify it
-# under the terms of version 2.1 of the GNU Lesser General Public License as
-# published by the Free Software Foundation.
-#
-# This library is distributed in the hope that it will be useful, but WITHOUT
-# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
-# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License
-# for more details.
-#
-# You should have received a copy of the GNU Lesser General Public License
-# along with this library; if not, see <http://www.gnu.org/licenses>.
 #
 
 from cgroup import Cgroup, CgroupVersion

--- a/ftests/044-pybindings-cgcreate_empty_controller.py
+++ b/ftests/044-pybindings-cgcreate_empty_controller.py
@@ -1,23 +1,10 @@
 #!/usr/bin/env python3
+# SPDX-License-Identifier: LGPL-2.1-only
 #
 # empty cgcreate functionality test using the python bindings
 #
 # Copyright (c) 2021-2022 Oracle and/or its affiliates.
 # Author: Tom Hromatka <tom.hromatka@oracle.com>
-#
-
-#
-# This library is free software; you can redistribute it and/or modify it
-# under the terms of version 2.1 of the GNU Lesser General Public License as
-# published by the Free Software Foundation.
-#
-# This library is distributed in the hope that it will be useful, but WITHOUT
-# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
-# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License
-# for more details.
-#
-# You should have received a copy of the GNU Lesser General Public License
-# along with this library; if not, see <http://www.gnu.org/licenses>.
 #
 
 from cgroup import Cgroup as CgroupCli

--- a/ftests/Makefile.am
+++ b/ftests/Makefile.am
@@ -1,22 +1,9 @@
+# SPDX-License-Identifier: LGPL-2.1-only
 #
 # libcgroup functional tests Makefile.am
 #
 # Copyright (c) 2019-2021 Oracle and/or its affiliates.
 # Author: Tom Hromatka <tom.hromatka@oracle.com>
-#
-
-#
-# This library is free software; you can redistribute it and/or modify it
-# under the terms of version 2.1 of the GNU Lesser General Public License as
-# published by the Free Software Foundation.
-#
-# This library is distributed in the hope that it will be useful, but WITHOUT
-# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
-# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License
-# for more details.
-#
-# You should have received a copy of the GNU Lesser General Public License
-# along with this library; if not, see <http://www.gnu.org/licenses>.
 #
 
 TESTS = ftests.sh ftests-nocontainer.sh

--- a/ftests/cgroup.py
+++ b/ftests/cgroup.py
@@ -1,22 +1,9 @@
+# SPDX-License-Identifier: LGPL-2.1-only
 #
 # Cgroup class for the libcgroup functional tests
 #
 # Copyright (c) 2019-2021 Oracle and/or its affiliates.
 # Author: Tom Hromatka <tom.hromatka@oracle.com>
-#
-
-#
-# This library is free software; you can redistribute it and/or modify it
-# under the terms of version 2.1 of the GNU Lesser General Public License as
-# published by the Free Software Foundation.
-#
-# This library is distributed in the hope that it will be useful, but WITHOUT
-# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
-# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License
-# for more details.
-#
-# You should have received a copy of the GNU Lesser General Public License
-# along with this library; if not, see <http://www.gnu.org/licenses>.
 #
 
 from container import ContainerError

--- a/ftests/config.py
+++ b/ftests/config.py
@@ -1,22 +1,9 @@
+# SPDX-License-Identifier: LGPL-2.1-only
 #
 # Config class for the libcgroup functional tests
 #
 # Copyright (c) 2019-2021 Oracle and/or its affiliates.
 # Author: Tom Hromatka <tom.hromatka@oracle.com>
-#
-
-#
-# This library is free software; you can redistribute it and/or modify it
-# under the terms of version 2.1 of the GNU Lesser General Public License as
-# published by the Free Software Foundation.
-#
-# This library is distributed in the hope that it will be useful, but WITHOUT
-# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
-# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License
-# for more details.
-#
-# You should have received a copy of the GNU Lesser General Public License
-# along with this library; if not, see <http://www.gnu.org/licenses>.
 #
 
 from container import Container

--- a/ftests/consts.py
+++ b/ftests/consts.py
@@ -1,22 +1,9 @@
+# SPDX-License-Identifier: LGPL-2.1-only
 #
 # Constants for the libcgroup functional tests
 #
 # Copyright (c) 2019-2021 Oracle and/or its affiliates.
 # Author: Tom Hromatka <tom.hromatka@oracle.com>
-#
-
-#
-# This library is free software; you can redistribute it and/or modify it
-# under the terms of version 2.1 of the GNU Lesser General Public License as
-# published by the Free Software Foundation.
-#
-# This library is distributed in the hope that it will be useful, but WITHOUT
-# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
-# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License
-# for more details.
-#
-# You should have received a copy of the GNU Lesser General Public License
-# along with this library; if not, see <http://www.gnu.org/licenses>.
 #
 
 import os

--- a/ftests/container.py
+++ b/ftests/container.py
@@ -1,22 +1,9 @@
+# SPDX-License-Identifier: LGPL-2.1-only
 #
 # Container class for the libcgroup functional tests
 #
 # Copyright (c) 2019-2021 Oracle and/or its affiliates.
 # Author: Tom Hromatka <tom.hromatka@oracle.com>
-#
-
-#
-# This library is free software; you can redistribute it and/or modify it
-# under the terms of version 2.1 of the GNU Lesser General Public License as
-# published by the Free Software Foundation.
-#
-# This library is distributed in the hope that it will be useful, but WITHOUT
-# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
-# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License
-# for more details.
-#
-# You should have received a copy of the GNU Lesser General Public License
-# along with this library; if not, see <http://www.gnu.org/licenses>.
 #
 
 from run import Run

--- a/ftests/controller.py
+++ b/ftests/controller.py
@@ -1,22 +1,9 @@
+# SPDX-License-Identifier: LGPL-2.1-only
 #
 # Cgroup class for the libcgroup functional tests
 #
 # Copyright (c) 2020 Oracle and/or its affiliates.
 # Author: Tom Hromatka <tom.hromatka@oracle.com>
-#
-
-#
-# This library is free software; you can redistribute it and/or modify it
-# under the terms of version 2.1 of the GNU Lesser General Public License as
-# published by the Free Software Foundation.
-#
-# This library is distributed in the hope that it will be useful, but WITHOUT
-# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
-# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License
-# for more details.
-#
-# You should have received a copy of the GNU Lesser General Public License
-# along with this library; if not, see <http://www.gnu.org/licenses>.
 #
 
 from log import Log

--- a/ftests/ftests-nocontainer.sh
+++ b/ftests/ftests-nocontainer.sh
@@ -1,2 +1,4 @@
 #!/bin/bash
+# SPDX-License-Identifier: LGPL-2.1-only
+
 ./ftests.py -l 10 -L ftests-nocontainer.log --no-container

--- a/ftests/ftests.py
+++ b/ftests/ftests.py
@@ -1,23 +1,10 @@
 #!/usr/bin/env python3
+# SPDX-License-Identifier: LGPL-2.1-only
 #
 # Main entry point for the libcgroup functional tests
 #
 # Copyright (c) 2019-2021 Oracle and/or its affiliates.
 # Author: Tom Hromatka <tom.hromatka@oracle.com>
-#
-
-#
-# This library is free software; you can redistribute it and/or modify it
-# under the terms of version 2.1 of the GNU Lesser General Public License as
-# published by the Free Software Foundation.
-#
-# This library is distributed in the hope that it will be useful, but WITHOUT
-# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
-# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License
-# for more details.
-#
-# You should have received a copy of the GNU Lesser General Public License
-# along with this library; if not, see <http://www.gnu.org/licenses>.
 #
 
 from config import Config

--- a/ftests/ftests.sh
+++ b/ftests/ftests.sh
@@ -1,2 +1,4 @@
 #!/bin/bash
+# SPDX-License-Identifier: LGPL-2.1-only
+
 ./ftests.py -l 10 -L ftests.log

--- a/ftests/log.py
+++ b/ftests/log.py
@@ -1,22 +1,9 @@
+# SPDX-License-Identifier: LGPL-2.1-only
 #
 # Log class for the libcgroup functional tests
 #
 # Copyright (c) 2019 Oracle and/or its affiliates.  All rights reserved.
 # Author: Tom Hromatka <tom.hromatka@oracle.com>
-#
-
-#
-# This library is free software; you can redistribute it and/or modify it
-# under the terms of version 2.1 of the GNU Lesser General Public License as
-# published by the Free Software Foundation.
-#
-# This library is distributed in the hope that it will be useful, but WITHOUT
-# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
-# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License
-# for more details.
-#
-# You should have received a copy of the GNU Lesser General Public License
-# along with this library; if not, see <http://www.gnu.org/licenses>.
 #
 
 import datetime

--- a/ftests/process.py
+++ b/ftests/process.py
@@ -1,22 +1,9 @@
+# SPDX-License-Identifier: LGPL-2.1-only
 #
 # Cgroup class for the libcgroup functional tests
 #
 # Copyright (c) 2020-2021 Oracle and/or its affiliates.
 # Author: Tom Hromatka <tom.hromatka@oracle.com>
-#
-
-#
-# This library is free software; you can redistribute it and/or modify it
-# under the terms of version 2.1 of the GNU Lesser General Public License as
-# published by the Free Software Foundation.
-#
-# This library is distributed in the hope that it will be useful, but WITHOUT
-# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
-# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License
-# for more details.
-#
-# You should have received a copy of the GNU Lesser General Public License
-# along with this library; if not, see <http://www.gnu.org/licenses>.
 #
 
 from container import ContainerError

--- a/ftests/run.py
+++ b/ftests/run.py
@@ -1,22 +1,9 @@
+# SPDX-License-Identifier: LGPL-2.1-only
 #
 # Run class for the libcgroup functional tests
 #
 # Copyright (c) 2019 Oracle and/or its affiliates.  All rights reserved.
 # Author: Tom Hromatka <tom.hromatka@oracle.com>
-#
-
-#
-# This library is free software; you can redistribute it and/or modify it
-# under the terms of version 2.1 of the GNU Lesser General Public License as
-# published by the Free Software Foundation.
-#
-# This library is distributed in the hope that it will be useful, but WITHOUT
-# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
-# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License
-# for more details.
-#
-# You should have received a copy of the GNU Lesser General Public License
-# along with this library; if not, see <http://www.gnu.org/licenses>.
 #
 
 from log import Log

--- a/ftests/utils.py
+++ b/ftests/utils.py
@@ -1,22 +1,9 @@
+# SPDX-License-Identifier: LGPL-2.1-only
 #
 # Utility functions for the libcgroup functional tests
 #
 # Copyright (c) 2020 Oracle and/or its affiliates.
 # Author: Tom Hromatka <tom.hromatka@oracle.com>
-#
-
-#
-# This library is free software; you can redistribute it and/or modify it
-# under the terms of version 2.1 of the GNU Lesser General Public License as
-# published by the Free Software Foundation.
-#
-# This library is distributed in the hope that it will be useful, but WITHOUT
-# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
-# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License
-# for more details.
-#
-# You should have received a copy of the GNU Lesser General Public License
-# along with this library; if not, see <http://www.gnu.org/licenses>.
 #
 
 from run import Run

--- a/gunit/001-path.cpp
+++ b/gunit/001-path.cpp
@@ -1,22 +1,9 @@
+/* SPDX-License-Identifier: LGPL-2.1-only */
 /**
  * libcgroup googletest for cg_build_path()
  *
  * Copyright (c) 2019 Oracle and/or its affiliates.  All rights reserved.
  * Author: Tom Hromatka <tom.hromatka@oracle.com>
- */
-
-/*
- * This library is free software; you can redistribute it and/or modify it
- * under the terms of version 2.1 of the GNU Lesser General Public License as
- * published by the Free Software Foundation.
- *
- * This library is distributed in the hope that it will be useful, but WITHOUT
- * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
- * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License
- * for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this library; if not, see <http://www.gnu.org/licenses>.
  */
 
 #include "gtest/gtest.h"

--- a/gunit/002-cgroup_parse_rules_options.cpp
+++ b/gunit/002-cgroup_parse_rules_options.cpp
@@ -1,22 +1,9 @@
+/* SPDX-License-Identifier: LGPL-2.1-only */
 /**
  * libcgroup googletest for cgroup_parse_rules_options()
  *
  * Copyright (c) 2019 Oracle and/or its affiliates.  All rights reserved.
  * Author: Tom Hromatka <tom.hromatka@oracle.com>
- */
-
-/*
- * This library is free software; you can redistribute it and/or modify it
- * under the terms of version 2.1 of the GNU Lesser General Public License as
- * published by the Free Software Foundation.
- *
- * This library is distributed in the hope that it will be useful, but WITHOUT
- * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
- * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License
- * for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this library; if not, see <http://www.gnu.org/licenses>.
  */
 
 #include "gtest/gtest.h"

--- a/gunit/003-cg_get_cgroups_from_proc_cgroups.cpp
+++ b/gunit/003-cg_get_cgroups_from_proc_cgroups.cpp
@@ -1,22 +1,9 @@
+/* SPDX-License-Identifier: LGPL-2.1-only */
 /**
  * libcgroup googletest for cg_get_cgroups_from_proc_cgroups()
  *
  * Copyright (c) 2019 Oracle and/or its affiliates.  All rights reserved.
  * Author: Tom Hromatka <tom.hromatka@oracle.com>
- */
-
-/*
- * This library is free software; you can redistribute it and/or modify it
- * under the terms of version 2.1 of the GNU Lesser General Public License as
- * published by the Free Software Foundation.
- *
- * This library is distributed in the hope that it will be useful, but WITHOUT
- * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
- * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License
- * for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this library; if not, see <http://www.gnu.org/licenses>.
  */
 
 #include "gtest/gtest.h"

--- a/gunit/004-cgroup_compare_ignore_rule.cpp
+++ b/gunit/004-cgroup_compare_ignore_rule.cpp
@@ -1,22 +1,9 @@
+/* SPDX-License-Identifier: LGPL-2.1-only */
 /**
  * libcgroup googletest for cgroup_compare_ignore_rule()
  *
  * Copyright (c) 2019 Oracle and/or its affiliates.  All rights reserved.
  * Author: Tom Hromatka <tom.hromatka@oracle.com>
- */
-
-/*
- * This library is free software; you can redistribute it and/or modify it
- * under the terms of version 2.1 of the GNU Lesser General Public License as
- * published by the Free Software Foundation.
- *
- * This library is distributed in the hope that it will be useful, but WITHOUT
- * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
- * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License
- * for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this library; if not, see <http://www.gnu.org/licenses>.
  */
 
 #include "gtest/gtest.h"

--- a/gunit/005-cgroup_compare_wildcard_procname.cpp
+++ b/gunit/005-cgroup_compare_wildcard_procname.cpp
@@ -1,22 +1,9 @@
+/* SPDX-License-Identifier: LGPL-2.1-only */
 /**
  * libcgroup googletest for cgroup_compare_wildcard_procname()
  *
  * Copyright (c) 2019 Oracle and/or its affiliates.  All rights reserved.
  * Author: Tom Hromatka <tom.hromatka@oracle.com>
- */
-
-/*
- * This library is free software; you can redistribute it and/or modify it
- * under the terms of version 2.1 of the GNU Lesser General Public License as
- * published by the Free Software Foundation.
- *
- * This library is distributed in the hope that it will be useful, but WITHOUT
- * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
- * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License
- * for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this library; if not, see <http://www.gnu.org/licenses>.
  */
 
 #include "gtest/gtest.h"

--- a/gunit/006-cgroup_get_cgroup.cpp
+++ b/gunit/006-cgroup_get_cgroup.cpp
@@ -1,22 +1,9 @@
+/* SPDX-License-Identifier: LGPL-2.1-only */
 /**
  * libcgroup googletest for cgroup_get_cgroup()
  *
  * Copyright (c) 2020 Oracle and/or its affiliates.
  * Author: Tom Hromatka <tom.hromatka@oracle.com>
- */
-
-/*
- * This library is free software; you can redistribute it and/or modify it
- * under the terms of version 2.1 of the GNU Lesser General Public License as
- * published by the Free Software Foundation.
- *
- * This library is distributed in the hope that it will be useful, but WITHOUT
- * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
- * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License
- * for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this library; if not, see <http://www.gnu.org/licenses>.
  */
 
 #include <bits/stdc++.h>

--- a/gunit/007-cgroup_process_v1_mount.cpp
+++ b/gunit/007-cgroup_process_v1_mount.cpp
@@ -1,22 +1,9 @@
+/* SPDX-License-Identifier: LGPL-2.1-only */
 /**
  * libcgroup googletest for cgroup_process_v1_mnt()
  *
  * Copyright (c) 2020 Oracle and/or its affiliates.
  * Author: Tom Hromatka <tom.hromatka@oracle.com>
- */
-
-/*
- * This library is free software; you can redistribute it and/or modify it
- * under the terms of version 2.1 of the GNU Lesser General Public License as
- * published by the Free Software Foundation.
- *
- * This library is distributed in the hope that it will be useful, but WITHOUT
- * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
- * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License
- * for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this library; if not, see <http://www.gnu.org/licenses>.
  */
 
 #include <mntent.h>

--- a/gunit/008-cgroup_process_v2_mount.cpp
+++ b/gunit/008-cgroup_process_v2_mount.cpp
@@ -1,22 +1,9 @@
+/* SPDX-License-Identifier: LGPL-2.1-only */
 /**
  * libcgroup googletest for cgroup_process_v2_mnt()
  *
  * Copyright (c) 2020 Oracle and/or its affiliates.
  * Author: Tom Hromatka <tom.hromatka@oracle.com>
- */
-
-/*
- * This library is free software; you can redistribute it and/or modify it
- * under the terms of version 2.1 of the GNU Lesser General Public License as
- * published by the Free Software Foundation.
- *
- * This library is distributed in the hope that it will be useful, but WITHOUT
- * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
- * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License
- * for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this library; if not, see <http://www.gnu.org/licenses>.
  */
 
 #include <ftw.h>

--- a/gunit/009-cgroup_set_values_recursive.cpp
+++ b/gunit/009-cgroup_set_values_recursive.cpp
@@ -1,22 +1,9 @@
+/* SPDX-License-Identifier: LGPL-2.1-only */
 /**
  * libcgroup googletest for cgroup_set_values_recursive()
  *
  * Copyright (c) 2020 Oracle and/or its affiliates.
  * Author: Tom Hromatka <tom.hromatka@oracle.com>
- */
-
-/*
- * This library is free software; you can redistribute it and/or modify it
- * under the terms of version 2.1 of the GNU Lesser General Public License as
- * published by the Free Software Foundation.
- *
- * This library is distributed in the hope that it will be useful, but WITHOUT
- * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
- * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License
- * for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this library; if not, see <http://www.gnu.org/licenses>.
  */
 
 #include <ftw.h>

--- a/gunit/010-cgroup_chown_chmod_tasks.cpp
+++ b/gunit/010-cgroup_chown_chmod_tasks.cpp
@@ -1,22 +1,9 @@
+/* SPDX-License-Identifier: LGPL-2.1-only */
 /**
  * libcgroup googletest for cgroup_chown_chmod_tasks()
  *
  * Copyright (c) 2020 Oracle and/or its affiliates.
  * Author: Tom Hromatka <tom.hromatka@oracle.com>
- */
-
-/*
- * This library is free software; you can redistribute it and/or modify it
- * under the terms of version 2.1 of the GNU Lesser General Public License as
- * published by the Free Software Foundation.
- *
- * This library is distributed in the hope that it will be useful, but WITHOUT
- * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
- * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License
- * for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this library; if not, see <http://www.gnu.org/licenses>.
  */
 
 #include <ftw.h>

--- a/gunit/011-cgroupv2_subtree_control.cpp
+++ b/gunit/011-cgroupv2_subtree_control.cpp
@@ -1,22 +1,9 @@
+/* SPDX-License-Identifier: LGPL-2.1-only */
 /**
  * libcgroup googletest for cgroupv2_subtree_control()
  *
  * Copyright (c) 2020 Oracle and/or its affiliates.
  * Author: Tom Hromatka <tom.hromatka@oracle.com>
- */
-
-/*
- * This library is free software; you can redistribute it and/or modify it
- * under the terms of version 2.1 of the GNU Lesser General Public License as
- * published by the Free Software Foundation.
- *
- * This library is distributed in the hope that it will be useful, but WITHOUT
- * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
- * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License
- * for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this library; if not, see <http://www.gnu.org/licenses>.
  */
 
 #include <ftw.h>

--- a/gunit/012-cgroup_create_cgroup.cpp
+++ b/gunit/012-cgroup_create_cgroup.cpp
@@ -1,22 +1,9 @@
+/* SPDX-License-Identifier: LGPL-2.1-only */
 /**
  * libcgroup googletest for cgroup_create_cgroup()
  *
  * Copyright (c) 2020 Oracle and/or its affiliates.
  * Author: Tom Hromatka <tom.hromatka@oracle.com>
- */
-
-/*
- * This library is free software; you can redistribute it and/or modify it
- * under the terms of version 2.1 of the GNU Lesser General Public License as
- * published by the Free Software Foundation.
- *
- * This library is distributed in the hope that it will be useful, but WITHOUT
- * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
- * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License
- * for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this library; if not, see <http://www.gnu.org/licenses>.
  */
 
 #include <dirent.h>

--- a/gunit/013-cgroup_build_tasks_procs_path.cpp
+++ b/gunit/013-cgroup_build_tasks_procs_path.cpp
@@ -1,22 +1,9 @@
+/* SPDX-License-Identifier: LGPL-2.1-only */
 /**
  * libcgroup googletest for cgroup_build_tasks_procs_path()
  *
  * Copyright (c) 2020 Oracle and/or its affiliates.
  * Author: Tom Hromatka <tom.hromatka@oracle.com>
- */
-
-/*
- * This library is free software; you can redistribute it and/or modify it
- * under the terms of version 2.1 of the GNU Lesser General Public License as
- * published by the Free Software Foundation.
- *
- * This library is distributed in the hope that it will be useful, but WITHOUT
- * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
- * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License
- * for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this library; if not, see <http://www.gnu.org/licenses>.
  */
 
 #include "gtest/gtest.h"

--- a/gunit/014-cgroupv2_get_subtree_control.cpp
+++ b/gunit/014-cgroupv2_get_subtree_control.cpp
@@ -1,22 +1,9 @@
+/* SPDX-License-Identifier: LGPL-2.1-only */
 /**
  * libcgroup googletest for cgroupv2_get_subtree_control()
  *
  * Copyright (c) 2020 Oracle and/or its affiliates.
  * Author: Tom Hromatka <tom.hromatka@oracle.com>
- */
-
-/*
- * This library is free software; you can redistribute it and/or modify it
- * under the terms of version 2.1 of the GNU Lesser General Public License as
- * published by the Free Software Foundation.
- *
- * This library is distributed in the hope that it will be useful, but WITHOUT
- * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
- * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License
- * for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this library; if not, see <http://www.gnu.org/licenses>.
  */
 
 #include <fcntl.h>

--- a/gunit/015-cgroupv2_controller_enabled.cpp
+++ b/gunit/015-cgroupv2_controller_enabled.cpp
@@ -1,22 +1,9 @@
+/* SPDX-License-Identifier: LGPL-2.1-only */
 /**
  * libcgroup googletest for cgroupv2_controller_enabled()
  *
  * Copyright (c) 2020 Oracle and/or its affiliates.
  * Author: Tom Hromatka <tom.hromatka@oracle.com>
- */
-
-/*
- * This library is free software; you can redistribute it and/or modify it
- * under the terms of version 2.1 of the GNU Lesser General Public License as
- * published by the Free Software Foundation.
- *
- * This library is distributed in the hope that it will be useful, but WITHOUT
- * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
- * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License
- * for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this library; if not, see <http://www.gnu.org/licenses>.
  */
 
 #include <ftw.h>

--- a/gunit/016-cgset_parse_r_flag.cpp
+++ b/gunit/016-cgset_parse_r_flag.cpp
@@ -1,22 +1,9 @@
+/* SPDX-License-Identifier: LGPL-2.1-only */
 /**
  * libcgroup googletest for parse_r_flag() in cgset
  *
  * Copyright (c) 2021 Oracle and/or its affiliates.
  * Author: Tom Hromatka <tom.hromatka@oracle.com>
- */
-
-/*
- * This library is free software; you can redistribute it and/or modify it
- * under the terms of version 2.1 of the GNU Lesser General Public License as
- * published by the Free Software Foundation.
- *
- * This library is distributed in the hope that it will be useful, but WITHOUT
- * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
- * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License
- * for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this library; if not, see <http://www.gnu.org/licenses>.
  */
 
 #include <ftw.h>

--- a/gunit/Makefile.am
+++ b/gunit/Makefile.am
@@ -1,22 +1,9 @@
+# SPDX-License-Identifier: LGPL-2.1-only
 #
 # libcgroup googletests Makefile.am
 #
 # Copyright (c) 2019 Oracle and/or its affiliates.  All rights reserved.
 # Author: Tom Hromatka <tom.hromatka@oracle.com>
-#
-
-#
-# This library is free software; you can redistribute it and/or modify it
-# under the terms of version 2.1 of the GNU Lesser General Public License as
-# published by the Free Software Foundation.
-#
-# This library is distributed in the hope that it will be useful, but WITHOUT
-# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
-# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License
-# for more details.
-#
-# You should have received a copy of the GNU Lesser General Public License
-# along with this library; if not, see <http://www.gnu.org/licenses>.
 #
 
 AM_CPPFLAGS = -I$(top_srcdir)/include \

--- a/gunit/gtest.cpp
+++ b/gunit/gtest.cpp
@@ -1,22 +1,9 @@
+/* SPDX-License-Identifier: LGPL-2.1-only */
 /**
  * libcgroup googletest main entry point
  *
  * Copyright (c) 2019 Oracle and/or its affiliates.  All rights reserved.
  * Author: Tom Hromatka <tom.hromatka@oracle.com>
- */
-
-/*
- * This library is free software; you can redistribute it and/or modify it
- * under the terms of version 2.1 of the GNU Lesser General Public License as
- * published by the Free Software Foundation.
- *
- * This library is distributed in the hope that it will be useful, but WITHOUT
- * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
- * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License
- * for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this library; if not, see <http://www.gnu.org/licenses>.
  */
 
 #include "gtest/gtest.h"


### PR DESCRIPTION
This patch series adopts SPDX license tag for all the source files, those
already have LGPL 2.1 boilerplate in them and those missing license information.
All the files in the project fall under project license, hence explicitly adding
`LGPL-2.1-only` identifier to the files missing license information. Adopting
SPDX license helps the compliance tools to determine the license and also
helps in reducing the repetitive license boilerplate across source files.