### PR TITLE
ftests: Add a test for the python bindings to cgroup_list_mount_points()

### DIFF
--- a/ftests/045-pybindings-list_mount_points.py
+++ b/ftests/045-pybindings-list_mount_points.py
@@ -1,0 +1,71 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: LGPL-2.1-only
+#
+# cgroup_list_mount_points functionality test using the python bindings
+#
+# Copyright (c) 2022 Oracle and/or its affiliates.
+# Author: Kamalesh Babulal <kamalesh.babulal@oracle.com>
+#
+
+from libcgroup import Cgroup, Version
+import consts
+import ftests
+import sys
+import os
+
+CGNAME = '045bindings'
+
+
+def prereqs(config):
+    if config.args.container:
+        result = consts.TEST_SKIPPED
+        cause = 'This test cannot be run within a container'
+        return result, cause
+
+    result = consts.TEST_PASSED
+    cause = None
+
+    return result, cause
+
+
+def setup(config):
+    return consts.TEST_PASSED, None
+
+
+def test(config):
+    result = consts.TEST_PASSED
+    cause = None
+
+    cg1 = Cgroup(CGNAME, Version.CGROUP_V1)
+    mount_points_v1 = cg1.cgroup_list_mount_points(Version.CGROUP_V1)
+    mount_points_v2 = cg1.cgroup_list_mount_points(Version.CGROUP_V2)
+    if not mount_points_v1 and not mount_points_v2:
+        result = consts.TEST_FAILED
+        cause = ("No cgroup mount point found")
+
+    return result, cause
+
+
+def teardown(config):
+    return consts.TEST_PASSED, None
+
+
+def main(config):
+    [result, cause] = prereqs(config)
+    if result != consts.TEST_PASSED:
+        return [result, cause]
+
+    setup(config)
+    [result, cause] = test(config)
+    teardown(config)
+
+    return [result, cause]
+
+
+if __name__ == '__main__':
+    config = ftests.parse_args()
+    # this test was invoked directly.  run only it
+    config.args.num = int(os.path.basename(__file__).split('-')[0])
+    sys.exit(ftests.main(config))
+
+# vim: set et ts=4 sw=4:


### PR DESCRIPTION
Add a functional test that exercises the `cgroup_list_mount_points()`
python bindings.
```
-----------------------------------------------------------------
Test Results:
        Run Date:                          Mar 24 06:35:52
        Passed:                                  1 test(s)
        Skipped:                                 0 test(s)
        Failed:                                  0 test(s)
-----------------------------------------------------------------
Timing Results:
        Test                                    Time (sec)
        --------------------------------------------------
        setup                                         0.00
        045-pybindings-list_mount_points.py           0.00
        teardown                                      0.00
        --------------------------------------------------
        Total Run Time                                0.00
```
Signed-off-by: Kamalesh Babulal <kamalesh.babulal@oracle.com>