### PR TITLE
[RFC] resize controller name to 32 from 4096 bytes

### DIFF
--- a/gunit/001-path.cpp
+++ b/gunit/001-path.cpp
@@ -44,7 +44,7 @@ class BuildPathV1Test : public ::testing::Test {
 
 		// Populate the mount table
 		for (i = 0; i < ENTRY_CNT; i++) {
-			snprintf(cg_mount_table[i].name, FILENAME_MAX,
+			snprintf(cg_mount_table[i].name, CONTROL_NAMELEN_MAX,
 				 "controller%d", i);
 			cg_mount_table[i].index = i;
 

--- a/gunit/006-cgroup_get_cgroup.cpp
+++ b/gunit/006-cgroup_get_cgroup.cpp
@@ -114,7 +114,7 @@ class CgroupGetCgroupTest : public ::testing::Test {
 		memset(&cg_namespace_table, 0, sizeof(cg_namespace_table));
 
 		for (i = 0; i < CONTROLLERS_CNT; i++) {
-			snprintf(cg_mount_table[i].name, FILENAME_MAX,
+			snprintf(cg_mount_table[i].name, CONTROL_NAMELEN_MAX,
 				 "%s", CONTROLLERS[i]);
 			snprintf(cg_mount_table[i].mount.path, FILENAME_MAX,
 				 "%s/%s", PARENT_DIR, CONTROLLERS[i]);

--- a/gunit/009-cgroup_set_values_recursive.cpp
+++ b/gunit/009-cgroup_set_values_recursive.cpp
@@ -85,7 +85,7 @@ TEST_F(SetValuesRecursiveTest, SuccessfulSetValues)
 	char *val;
 	FILE *f;
 
-	ret = snprintf(ctrlr.name, FILENAME_MAX - 1, "cpu");
+	ret = snprintf(ctrlr.name, CONTROL_NAMELEN_MAX, "cpu");
 	ASSERT_GT(ret, 0);
 
 	for (i = 0; i < NAMES_CNT; i++) {

--- a/gunit/012-cgroup_create_cgroup.cpp
+++ b/gunit/012-cgroup_create_cgroup.cpp
@@ -59,7 +59,7 @@ class CgroupCreateCgroupTest : public ::testing::Test {
 		memset(&cg_namespace_table, 0, sizeof(cg_namespace_table));
 
 		for (i = 0; i < CONTROLLERS_CNT; i++) {
-			snprintf(cg_mount_table[i].name, FILENAME_MAX,
+			snprintf(cg_mount_table[i].name, CONTROL_NAMELEN_MAX,
 				 "%s", CONTROLLERS[i]);
 			cg_mount_table[i].version = VERSIONS[i];
 

--- a/gunit/013-cgroup_build_tasks_procs_path.cpp
+++ b/gunit/013-cgroup_build_tasks_procs_path.cpp
@@ -44,7 +44,7 @@ class BuildTasksProcPathTest : public ::testing::Test {
 
 		// Populate the mount table
 		for (i = 0; i < ENTRY_CNT; i++) {
-			snprintf(cg_mount_table[i].name, FILENAME_MAX,
+			snprintf(cg_mount_table[i].name, CONTROL_NAMELEN_MAX,
 				 "controller%d", i);
 			cg_mount_table[i].index = i;
 

--- a/gunit/015-cgroupv2_controller_enabled.cpp
+++ b/gunit/015-cgroupv2_controller_enabled.cpp
@@ -87,7 +87,7 @@ class CgroupV2ControllerEnabled : public ::testing::Test {
 		memset(&cg_namespace_table, 0, sizeof(cg_namespace_table));
 
 		for (i = 0; i < CONTROLLERS_CNT; i++) {
-			snprintf(cg_mount_table[i].name, FILENAME_MAX,
+			snprintf(cg_mount_table[i].name, CONTROL_NAMELEN_MAX,
 				 "%s", CONTROLLERS[i]);
 			snprintf(cg_mount_table[i].mount.path, FILENAME_MAX,
 				 "%s", PARENT_DIR);


### PR DESCRIPTION
This patch set replaces the usage of `FILENAME_MAX` definition with
`CONTROL_NAMELEN_MAX` for controller name size index of
`struct cg_controller::name` and `struct cg_mount_table_s::name` in the
test cases referencing those structures.