### PR TITLE
tests/016: fix the cause in prereqs

### DIFF
--- a/ftests/016-cgget-invalid_options.py
+++ b/ftests/016-cgget-invalid_options.py
@@ -26,7 +26,7 @@ def prereqs(config):
     # This causes issues with the error handling of this test
     if not config.args.container:
         result = consts.TEST_SKIPPED
-        cause = 'This test cannot be run outside of a container'
+        cause = 'This test must be run within a container'
         return result, cause
 
     return result, cause


### PR DESCRIPTION
Match the cause message in the prereqs(), for containers check with
other test cases.  This helps the automated scripts to check/match
for the right errors.

Signed-off-by: Kamalesh Babulal <kamalesh.babulal@oracle.com>