### PR TITLE
fix issues on unsuccessful no-container runs

### DIFF
--- a/ftests/019-cgconfig-uidgid_dperm_fperm.py
+++ b/ftests/019-cgconfig-uidgid_dperm_fperm.py
@@ -50,7 +50,7 @@ def setup(config):
         config.container.run(['groupadd', GROUP])
     else:
         Run.run(['sudo', 'useradd', '-p', 'Test019#1', USER])
-        Run.run(['sudo', 'groupadd', GROUP])
+        Run.run(['sudo', 'groupadd', '-f', GROUP])
 
 
 def test(config):
@@ -111,7 +111,7 @@ def teardown(config):
             config.container.run(['userdel', USER])
             config.container.run(['groupdel', GROUP])
         else:
-            Run.run(['sudo', 'userdel', USER])
+            Run.run(['sudo', 'userdel', '-r', USER])
             Run.run(['sudo', 'groupdel', GROUP])
     except (ContainerError, RunError, ValueError):
         pass

--- a/ftests/020-cgconfig-tasks_perms_owner.py
+++ b/ftests/020-cgconfig-tasks_perms_owner.py
@@ -54,7 +54,7 @@ def setup(config):
         config.container.run(['groupadd', GROUP])
     else:
         Run.run(['sudo', 'useradd', '-p', 'Test020#1', USER])
-        Run.run(['sudo', 'groupadd', GROUP])
+        Run.run(['sudo', 'groupadd', '-f', GROUP])
 
 
 def test(config):
@@ -106,7 +106,7 @@ def teardown(config):
             config.container.run(['userdel', USER])
             config.container.run(['groupdel', GROUP])
         else:
-            Run.run(['sudo', 'userdel', USER])
+            Run.run(['sudo', 'userdel', '-r', USER])
             Run.run(['sudo', 'groupdel', GROUP])
     except (ContainerError, RunError, ValueError):
         pass


### PR DESCRIPTION
Running the test with --no-container, might cause an issue with useradd
or groupadd command if the home directory of the test user exists/test
user group exists.

The home directory of the user doesn't get removed by default on all
distros, so explicitly pass the '-r' flag to userdel to remove the
directory.  Whereas user group might exist due to unsuccessful test
runs, address it by passing '-f' flags to groupadd command, that
returns success even if the group exists, that will be removed
by the groupdel command at the exit.

This is not an issue with container test cases, because they are
created and destroyed for every test case execution. This patch
series fixes the following issues in the test cases 19 and 20.