### PR TITLE
Adopt to newer cpu.* output in /sys/fs/cgroup/

### DIFF
--- a/ftests/009-cgget-g_flag_controller_only.py
+++ b/ftests/009-cgget-g_flag_controller_only.py
@@ -16,82 +16,110 @@ import os
 CONTROLLER = 'cpu'
 CGNAME = '009cgget'
 
-EXPECTED_OUT_V1 = '''009cgget:
-cpu.cfs_period_us: 100000
-cpu.stat: nr_periods 0
-        nr_throttled 0
-        throttled_time 0
-cpu.shares: 1024
-cpu.cfs_quota_us: -1
-cpu.uclamp.min: 0.00
-cpu.uclamp.max: max
-'''
+EXPECTED_OUT_V1 = [
+    '''009cgget:
+    cpu.cfs_period_us: 100000
+    cpu.stat: nr_periods 0
+            nr_throttled 0
+            throttled_time 0
+    cpu.shares: 1024
+    cpu.cfs_quota_us: -1
+    cpu.uclamp.min: 0.00
+    cpu.uclamp.max: max''',
+    # cfs_bandwidth without cpu.stat nr_busts, burst_time
+    '''009cgget:
+    cpu.cfs_burst_us: 0
+    cpu.cfs_period_us: 100000
+    cpu.stat: nr_periods 0
+            nr_throttled 0
+            throttled_time 0
+    cpu.shares: 1024
+    cpu.idle: 0
+    cpu.cfs_quota_us: -1
+    cpu.uclamp.min: 0.00
+    cpu.uclamp.max: max''',
+    # cfs_bandwidth with cpu.stat nr_busts, burst_time
+    '''009cgget:
+    cpu.cfs_burst_us: 0
+    cpu.cfs_period_us: 100000
+    cpu.stat: nr_periods 0
+            nr_throttled 0
+            throttled_time 0
+            nr_bursts 0
+            burst_time 0
+    cpu.shares: 1024
+    cpu.idle: 0
+    cpu.cfs_quota_us: -1
+    cpu.uclamp.min: 0.00
+    cpu.uclamp.max: max'''
+]
 
-EXPECTED_OUT_V1_CFS_BANDWIDTH = '''009cgget:
-cpu.cfs_burst_us: 0
-cpu.cfs_period_us: 100000
-cpu.stat: nr_periods 0
-        nr_throttled 0
-        throttled_time 0
-        nr_bursts 0
-        burst_time 0
-cpu.shares: 1024
-cpu.idle: 0
-cpu.cfs_quota_us: -1
-cpu.uclamp.min: 0.00
-cpu.uclamp.max: max
-'''
-
-EXPECTED_OUT_V2 = '''009cgget:
-cpu.weight: 100
-cpu.stat: usage_usec 0
-        user_usec 0
-        system_usec 0
-        nr_periods 0
-        nr_throttled 0
-        throttled_usec 0
-cpu.weight.nice: 0
-cpu.pressure: some avg10=0.00 avg60=0.00 avg300=0.00 total=0
-cpu.max: max 100000
-cpu.uclamp.min: 0.00
-cpu.uclamp.max: max
-'''
-
-EXPECTED_OUT_V2_PSI = '''009cgget:
-cpu.weight: 100
-cpu.stat: usage_usec 0
-        user_usec 0
-        system_usec 0
-        nr_periods 0
-        nr_throttled 0
-        throttled_usec 0
-cpu.weight.nice: 0
-cpu.pressure: some avg10=0.00 avg60=0.00 avg300=0.00 total=0
-        full avg10=0.00 avg60=0.00 avg300=0.00 total=0
-cpu.max: max 100000
-cpu.uclamp.min: 0.00
-cpu.uclamp.max: max
-'''
-
-EXPECTED_OUT_V2_PSI_CFS_BANDWIDTH = '''009cgget:
-cpu.weight: 100
-cpu.stat: usage_usec 0
-        user_usec 0
-        system_usec 0
-        nr_periods 0
-        nr_throttled 0
-        throttled_usec 0
-        nr_bursts 0
-        burst_usec 0
-cpu.weight.nice: 0
-cpu.pressure: some avg10=0.00 avg60=0.00 avg300=0.00 total=0
-        full avg10=0.00 avg60=0.00 avg300=0.00 total=0
-cpu.idle: 0
-cpu.max.burst: 0
-cpu.max: max 100000
-cpu.uclamp.min: 0.00
-cpu.uclamp.max: max
-'''
+EXPECTED_OUT_V2 = [
+    '''009cgget:
+    cpu.weight: 100
+    cpu.stat: usage_usec 0
+            user_usec 0
+            system_usec 0
+            nr_periods 0
+            nr_throttled 0
+            throttled_usec 0
+    cpu.weight.nice: 0
+    cpu.pressure: some avg10=0.00 avg60=0.00 avg300=0.00 total=0
+    cpu.max: max 100000
+    cpu.uclamp.min: 0.00
+    cpu.uclamp.max: max''',
+    # with PSI
+    '''009cgget:
+    cpu.weight: 100
+    cpu.stat: usage_usec 0
+            user_usec 0
+            system_usec 0
+            nr_periods 0
+            nr_throttled 0
+            throttled_usec 0
+    cpu.weight.nice: 0
+    cpu.pressure: some avg10=0.00 avg60=0.00 avg300=0.00 total=0
+            full avg10=0.00 avg60=0.00 avg300=0.00 total=0
+    cpu.max: max 100000
+    cpu.uclamp.min: 0.00
+    cpu.uclamp.max: max''',
+    # with PSI, cfs_bandwidth without cpu.stat nr_busts, burst_time
+    '''009cgget:
+    cpu.weight: 100
+    cpu.stat: usage_usec 0
+            user_usec 0
+            system_usec 0
+            nr_periods 0
+            nr_throttled 0
+            throttled_usec 0
+    cpu.weight.nice: 0
+    cpu.pressure: some avg10=0.00 avg60=0.00 avg300=0.00 total=0
+            full avg10=0.00 avg60=0.00 avg300=0.00 total=0
+    cpu.idle: 0
+    cpu.max.burst: 0
+    cpu.max: max 100000
+    cpu.uclamp.min: 0.00
+    cpu.uclamp.max: max''',
+    # with PSI, cfs_bandwidth with cpu.stat nr_busts, burst_time
+    '''009cgget:
+    cpu.weight: 100
+    cpu.stat: usage_usec 0
+            user_usec 0
+            system_usec 0
+            nr_periods 0
+            nr_throttled 0
+            throttled_usec 0
+            nr_bursts 0
+            burst_usec 0
+    cpu.weight.nice: 0
+    cpu.pressure: some avg10=0.00 avg60=0.00 avg300=0.00 total=0
+            full avg10=0.00 avg60=0.00 avg300=0.00 total=0
+    cpu.idle: 0
+    cpu.max.burst: 0
+    cpu.max: max 100000
+    cpu.uclamp.min: 0.00
+    cpu.uclamp.max: max'''
+]
 
 
 def prereqs(config):
@@ -114,18 +142,13 @@ def test(config):
     version = CgroupVersion.get_version(CONTROLLER)
 
     if version == CgroupVersion.CGROUP_V1:
-        expected_out = EXPECTED_OUT_V1
-
-        if len(out.splitlines()) != len(expected_out.splitlines()):
-            expected_out = EXPECTED_OUT_V1_CFS_BANDWIDTH
+        for expected_out in EXPECTED_OUT_V1:
+            if len(out.splitlines()) == len(expected_out.splitlines()):
+                break
     elif version == CgroupVersion.CGROUP_V2:
-        expected_out = EXPECTED_OUT_V2
-
-        if len(out.splitlines()) != len(expected_out.splitlines()):
-            expected_out = EXPECTED_OUT_V2_PSI
-
-            if len(out.splitlines()) != len(expected_out.splitlines()):
-                expected_out = EXPECTED_OUT_V2_PSI_CFS_BANDWIDTH
+        for expected_out in EXPECTED_OUT_V2:
+            if len(out.splitlines()) == len(expected_out.splitlines()):
+                break
 
     if len(out.splitlines()) != len(expected_out.splitlines()):
         result = consts.TEST_FAILED

--- a/ftests/010-cgget-g_flag_controller_and_cgroup.py
+++ b/ftests/010-cgget-g_flag_controller_and_cgroup.py
@@ -16,77 +16,103 @@ import os
 CONTROLLER = 'cpu'
 CGNAME = '010cgget'
 
-EXPECTED_OUT_V1 = '''cpu.cfs_period_us: 100000
-cpu.stat: nr_periods 0
-        nr_throttled 0
-        throttled_time 0
-cpu.shares: 1024
-cpu.cfs_quota_us: -1
-cpu.uclamp.min: 0.00
-cpu.uclamp.max: max
-'''
+EXPECTED_OUT_V1 = [
+    '''cpu.cfs_period_us: 100000
+    cpu.stat: nr_periods 0
+            nr_throttled 0
+            throttled_time 0
+    cpu.shares: 1024
+    cpu.cfs_quota_us: -1
+    cpu.uclamp.min: 0.00
+    cpu.uclamp.max: max''',
+    # cfs_bandwidth without cpu.stat nr_busts, burst_time
+    '''cpu.cfs_burst_us: 0
+    cpu.cfs_period_us: 100000
+    cpu.stat: nr_periods 0
+            nr_throttled 0
+            throttled_time 0
+    cpu.shares: 1024
+    cpu.idle: 0
+    cpu.cfs_quota_us: -1
+    cpu.uclamp.min: 0.00
+    cpu.uclamp.max: max''',
+    # cfs_bandwidth with cpu.stat nr_busts, burst_time
+    '''cpu.cfs_burst_us: 0
+    cpu.cfs_period_us: 100000
+    cpu.stat: nr_periods 0
+            nr_throttled 0
+            throttled_time 0
+            nr_bursts 0
+            burst_time 0
+    cpu.shares: 1024
+    cpu.idle: 0
+    cpu.cfs_quota_us: -1
+    cpu.uclamp.min: 0.00
+    cpu.uclamp.max: max'''
+]
 
-EXPECTED_OUT_V1_CFS_BANDWIDTH = '''cpu.cfs_burst_us: 0
-cpu.cfs_period_us: 100000
-cpu.stat: nr_periods 0
-        nr_throttled 0
-        throttled_time 0
-        nr_bursts 0
-        burst_time 0
-cpu.shares: 1024
-cpu.idle: 0
-cpu.cfs_quota_us: -1
-cpu.uclamp.min: 0.00
-cpu.uclamp.max: max
-'''
-
-EXPECTED_OUT_V2 = '''cpu.weight: 100
-cpu.stat: usage_usec 0
-        user_usec 0
-        system_usec 0
-        nr_periods 0
-        nr_throttled 0
-        throttled_usec 0
-cpu.weight.nice: 0
-cpu.pressure: some avg10=0.00 avg60=0.00 avg300=0.00 total=0
-cpu.max: max 100000
-cpu.uclamp.min: 0.00
-cpu.uclamp.max: max
-'''
-
-EXPECTED_OUT_V2_PSI = '''cpu.weight: 100
-cpu.stat: usage_usec 0
-        user_usec 0
-        system_usec 0
-        nr_periods 0
-        nr_throttled 0
-        throttled_usec 0
-cpu.weight.nice: 0
-cpu.pressure: some avg10=0.00 avg60=0.00 avg300=0.00 total=0
-        full avg10=0.00 avg60=0.00 avg300=0.00 total=0
-cpu.max: max 100000
-cpu.uclamp.min: 0.00
-cpu.uclamp.max: max
-'''
-
-EXPECTED_OUT_V2_PSI_CFS_BANDWIDTH = '''cpu.weight: 100
-cpu.stat: usage_usec 0
-        user_usec 0
-        system_usec 0
-        nr_periods 0
-        nr_throttled 0
-        throttled_usec 0
-        nr_bursts 0
-        burst_usec 0
-cpu.weight.nice: 0
-cpu.pressure: some avg10=0.00 avg60=0.00 avg300=0.00 total=0
-        full avg10=0.00 avg60=0.00 avg300=0.00 total=0
-cpu.idle: 0
-cpu.max.burst: 0
-cpu.max: max 100000
-cpu.uclamp.min: 0.00
-cpu.uclamp.max: max
-'''
+EXPECTED_OUT_V2 = [
+    '''cpu.weight: 100
+    cpu.stat: usage_usec 0
+            user_usec 0
+            system_usec 0
+            nr_periods 0
+            nr_throttled 0
+            throttled_usec 0
+    cpu.weight.nice: 0
+    cpu.pressure: some avg10=0.00 avg60=0.00 avg300=0.00 total=0
+    cpu.max: max 100000
+    cpu.uclamp.min: 0.00
+    cpu.uclamp.max: max''',
+    # with PSI
+    '''cpu.weight: 100
+    cpu.stat: usage_usec 0
+            user_usec 0
+            system_usec 0
+            nr_periods 0
+            nr_throttled 0
+            throttled_usec 0
+    cpu.weight.nice: 0
+    cpu.pressure: some avg10=0.00 avg60=0.00 avg300=0.00 total=0
+            full avg10=0.00 avg60=0.00 avg300=0.00 total=0
+    cpu.max: max 100000
+    cpu.uclamp.min: 0.00
+    cpu.uclamp.max: max''',
+    # with PSI, cfs_bandwidth without cpu.stat nr_busts, burst_time
+    '''cpu.weight: 100
+    cpu.stat: usage_usec 0
+            user_usec 0
+            system_usec 0
+            nr_periods 0
+            nr_throttled 0
+            throttled_usec 0
+    cpu.weight.nice: 0
+    cpu.pressure: some avg10=0.00 avg60=0.00 avg300=0.00 total=0
+            full avg10=0.00 avg60=0.00 avg300=0.00 total=0
+    cpu.idle: 0
+    cpu.max.burst: 0
+    cpu.max: max 100000
+    cpu.uclamp.min: 0.00
+    cpu.uclamp.max: max''',
+    # with PSI, cfs_bandwidth with cpu.stat nr_busts, burst_time
+    '''cpu.weight: 100
+    cpu.stat: usage_usec 0
+            user_usec 0
+            system_usec 0
+            nr_periods 0
+            nr_throttled 0
+            throttled_usec 0
+            nr_bursts 0
+            burst_usec 0
+    cpu.weight.nice: 0
+    cpu.pressure: some avg10=0.00 avg60=0.00 avg300=0.00 total=0
+            full avg10=0.00 avg60=0.00 avg300=0.00 total=0
+    cpu.idle: 0
+    cpu.max.burst: 0
+    cpu.max: max 100000
+    cpu.uclamp.min: 0.00
+    cpu.uclamp.max: max''',
+]
 
 
 def prereqs(config):
@@ -110,18 +136,13 @@ def test(config):
     version = CgroupVersion.get_version(CONTROLLER)
 
     if version == CgroupVersion.CGROUP_V1:
-        expected_out = EXPECTED_OUT_V1
-
-        if len(out.splitlines()) != len(expected_out.splitlines()):
-            expected_out = EXPECTED_OUT_V1_CFS_BANDWIDTH
+        for expected_out in EXPECTED_OUT_V1:
+            if len(out.splitlines()) == len(expected_out.splitlines()):
+                break
     elif version == CgroupVersion.CGROUP_V2:
-        expected_out = EXPECTED_OUT_V2
-
-        if len(out.splitlines()) != len(expected_out.splitlines()):
-            expected_out = EXPECTED_OUT_V2_PSI
-
-            if len(out.splitlines()) != len(expected_out.splitlines()):
-                expected_out = EXPECTED_OUT_V2_PSI_CFS_BANDWIDTH
+        for expected_out in EXPECTED_OUT_V2:
+            if len(out.splitlines()) == len(expected_out.splitlines()):
+                break
 
     if len(out.splitlines()) != len(expected_out.splitlines()):
         result = consts.TEST_FAILED

--- a/ftests/013-cgget-multiple_g_flags.py
+++ b/ftests/013-cgget-multiple_g_flags.py
@@ -17,97 +17,131 @@ CONTROLLER1 = 'pids'
 CONTROLLER2 = 'cpu'
 CGNAME = '013cgget'
 
-EXPECTED_OUT_V1 = '''013cgget:
-pids.current: 0
-pids.events: max 0
-pids.max: max
-cpu.cfs_period_us: 100000
-cpu.stat: nr_periods 0
-        nr_throttled 0
-        throttled_time 0
-cpu.shares: 1024
-cpu.cfs_quota_us: -1
-cpu.uclamp.min: 0.00
-cpu.uclamp.max: max
-'''
+EXPECTED_OUT_V1 = [
+    '''013cgget:
+    pids.current: 0
+    pids.events: max 0
+    pids.max: max
+    cpu.cfs_period_us: 100000
+    cpu.stat: nr_periods 0
+            nr_throttled 0
+            throttled_time 0
+    cpu.shares: 1024
+    cpu.cfs_quota_us: -1
+    cpu.uclamp.min: 0.00
+    cpu.uclamp.max: max''',
+    # with cfs_bandwidth without cpu.stat nr_busts, burst_time
+    '''013cgget:
+    pids.current: 0
+    pids.events: max 0
+    pids.max: max
+    cpu.cfs_burst_us: 0
+    cpu.cfs_period_us: 100000
+    cpu.stat: nr_periods 0
+            nr_throttled 0
+            throttled_time 0
+    cpu.shares: 1024
+    cpu.idle: 0
+    cpu.cfs_quota_us: -1
+    cpu.uclamp.min: 0.00
+    cpu.uclamp.max: max''',
+    # with cfs_bandwidth with cpu.stat nr_busts, burst_time
+    '''013cgget:
+    pids.current: 0
+    pids.events: max 0
+    pids.max: max
+    cpu.cfs_burst_us: 0
+    cpu.cfs_period_us: 100000
+    cpu.stat: nr_periods 0
+            nr_throttled 0
+            throttled_time 0
+            nr_bursts 0
+            burst_time 0
+    cpu.shares: 1024
+    cpu.idle: 0
+    cpu.cfs_quota_us: -1
+    cpu.uclamp.min: 0.00
+    cpu.uclamp.max: max'''
+]
 
-EXPECTED_OUT_V1_CFS_BANDWIDTH = '''013cgget:
-pids.current: 0
-pids.events: max 0
-pids.max: max
-cpu.cfs_burst_us: 0
-cpu.cfs_period_us: 100000
-cpu.stat: nr_periods 0
-        nr_throttled 0
-        throttled_time 0
-        nr_bursts 0
-        burst_time 0
-cpu.shares: 1024
-cpu.idle: 0
-cpu.cfs_quota_us: -1
-cpu.uclamp.min: 0.00
-cpu.uclamp.max: max
-'''
-
-EXPECTED_OUT_V2 = '''013cgget:
-pids.current: 0
-pids.events: max 0
-pids.max: max
-cpu.weight: 100
-cpu.stat: usage_usec 0
-        user_usec 0
-        system_usec 0
-        nr_periods 0
-        nr_throttled 0
-        throttled_usec 0
-cpu.weight.nice: 0
-cpu.pressure: some avg10=0.00 avg60=0.00 avg300=0.00 total=0
-cpu.max: max 100000
-cpu.uclamp.min: 0.00
-cpu.uclamp.max: max
-'''
-
-EXPECTED_OUT_V2_PSI = '''013cgget:
-pids.current: 0
-pids.events: max 0
-pids.max: max
-cpu.weight: 100
-cpu.stat: usage_usec 0
-        user_usec 0
-        system_usec 0
-        nr_periods 0
-        nr_throttled 0
-        throttled_usec 0
-cpu.weight.nice: 0
-cpu.pressure: some avg10=0.00 avg60=0.00 avg300=0.00 total=0
-        full avg10=0.00 avg60=0.00 avg300=0.00 total=0
-cpu.max: max 100000
-cpu.uclamp.min: 0.00
-cpu.uclamp.max: max
-'''
-
-EXPECTED_OUT_V2_PSI_CFS_BANDWIDTH = '''013cgget:
-pids.current: 0
-pids.events: max 0
-pids.max: max
-cpu.weight: 100
-cpu.stat: usage_usec 0
-        user_usec 0
-        system_usec 0
-        nr_periods 0
-        nr_throttled 0
-        throttled_usec 0
-        nr_bursts 0
-        burst_usec 0
-cpu.weight.nice: 0
-cpu.pressure: some avg10=0.00 avg60=0.00 avg300=0.00 total=0
-        full avg10=0.00 avg60=0.00 avg300=0.00 total=0
-cpu.idle: 0
-cpu.max.burst: 0
-cpu.max: max 100000
-cpu.uclamp.min: 0.00
-cpu.uclamp.max: max
-'''
+EXPECTED_OUT_V2 = [
+    '''013cgget:
+    pids.current: 0
+    pids.events: max 0
+    pids.max: max
+    cpu.weight: 100
+    cpu.stat: usage_usec 0
+            user_usec 0
+            system_usec 0
+            nr_periods 0
+            nr_throttled 0
+            throttled_usec 0
+    cpu.weight.nice: 0
+    cpu.pressure: some avg10=0.00 avg60=0.00 avg300=0.00 total=0
+    cpu.max: max 100000
+    cpu.uclamp.min: 0.00
+    cpu.uclamp.max: max''',
+    # with PSI
+    '''013cgget:
+    pids.current: 0
+    pids.events: max 0
+    pids.max: max
+    cpu.weight: 100
+    cpu.stat: usage_usec 0
+            user_usec 0
+            system_usec 0
+            nr_periods 0
+            nr_throttled 0
+            throttled_usec 0
+    cpu.weight.nice: 0
+    cpu.pressure: some avg10=0.00 avg60=0.00 avg300=0.00 total=0
+            full avg10=0.00 avg60=0.00 avg300=0.00 total=0
+    cpu.max: max 100000
+    cpu.uclamp.min: 0.00
+    cpu.uclamp.max: max''',
+    # with PSI, cfs_bandwidth without cpu.stat nr_busts, burst_time
+    '''013cgget:
+    pids.current: 0
+    pids.events: max 0
+    pids.max: max
+    cpu.weight: 100
+    cpu.stat: usage_usec 0
+            user_usec 0
+            system_usec 0
+            nr_periods 0
+            nr_throttled 0
+            throttled_usec 0
+    cpu.weight.nice: 0
+    cpu.pressure: some avg10=0.00 avg60=0.00 avg300=0.00 total=0
+            full avg10=0.00 avg60=0.00 avg300=0.00 total=0
+    cpu.idle: 0
+    cpu.max.burst: 0
+    cpu.max: max 100000
+    cpu.uclamp.min: 0.00
+    cpu.uclamp.max: max''',
+    # with PSI, cfs_bandwidth with cpu.stat nr_busts, burst_time
+    '''013cgget:
+    pids.current: 0
+    pids.events: max 0
+    pids.max: max
+    cpu.weight: 100
+    cpu.stat: usage_usec 0
+            user_usec 0
+            system_usec 0
+            nr_periods 0
+            nr_throttled 0
+            throttled_usec 0
+            nr_bursts 0
+            burst_usec 0
+    cpu.weight.nice: 0
+    cpu.pressure: some avg10=0.00 avg60=0.00 avg300=0.00 total=0
+            full avg10=0.00 avg60=0.00 avg300=0.00 total=0
+    cpu.idle: 0
+    cpu.max.burst: 0
+    cpu.max: max 100000
+    cpu.uclamp.min: 0.00
+    cpu.uclamp.max: max'''
+]
 
 
 def prereqs(config):
@@ -132,18 +166,13 @@ def test(config):
     version = CgroupVersion.get_version(CONTROLLER1)
 
     if version == CgroupVersion.CGROUP_V1:
-        expected_out = EXPECTED_OUT_V1
-
-        if len(out.splitlines()) != len(expected_out.splitlines()):
-            expected_out = EXPECTED_OUT_V1_CFS_BANDWIDTH
+        for expected_out in EXPECTED_OUT_V1:
+            if len(out.splitlines()) == len(expected_out.splitlines()):
+                break
     elif version == CgroupVersion.CGROUP_V2:
-        expected_out = EXPECTED_OUT_V2
-
-        if len(out.splitlines()) != len(expected_out.splitlines()):
-            expected_out = EXPECTED_OUT_V2_PSI
-
-            if len(out.splitlines()) != len(expected_out.splitlines()):
-                expected_out = EXPECTED_OUT_V2_PSI_CFS_BANDWIDTH
+        for expected_out in EXPECTED_OUT_V2:
+            if len(out.splitlines()) == len(expected_out.splitlines()):
+                break
 
     if len(out.splitlines()) != len(expected_out.splitlines()):
         result = consts.TEST_FAILED


### PR DESCRIPTION
With Ubuntu 5.15.0-1014 kernel, there are a few changes to the output
of cgget -g cpu:<cgroup> provides for both cgroup V1 and V2:
**cgroup V1:**

- new stat files cpu.cfs_burst_us. cpu.idle

**cgroup V2:**

- new stat files cpu.idle, cpu.max.burst
    
adopt these changes while looking for expected out based on the cgroup
version. Also, convert the expected out templates into per cgroup
version list[], making it easier to match using a for loop, instead of
nested if else. Using a list also makes it easier to append any new
changes to the output template.
