### PR TITLE
[RFC] gunit: add installcheck

### DIFF
--- a/gunit/Makefile.am
+++ b/gunit/Makefile.am
@@ -6,6 +6,8 @@
 # Author: Tom Hromatka <tom.hromatka@oracle.com>
 #
 
+TEST_INSTALL_DIR=$(DESTDIR)/$(libdir)/libcgroup/tests
+
 AM_CPPFLAGS = -I$(top_srcdir)/include \
 	      -I$(top_srcdir)/src \
 	      -I$(top_srcdir)/src/tools \
@@ -43,8 +45,16 @@ gtest_SOURCES = gtest.cpp \
 		014-cgroupv2_get_subtree_control.cpp \
 		015-cgroupv2_controller_enabled.cpp \
 		016-cgset_parse_r_flag.cpp
-gtest_LDFLAGS = -L$(top_srcdir)/googletest/googletest -l:libgtest.so \
+gtest_LDFLAGS = -L$(top_srcdir)/googletest/googletest -l:libgtest.so	\
+		-rpath $(TEST_INSTALL_DIR) \
 		-rpath $(abs_top_srcdir)/googletest/googletest
+
+installcheck-local:
+	$(MAKE) $(AM_MAKEFLAGS) gtest
+	test -d $(TEST_INSTALL_DIR) || mkdir -p $(TEST_INSTALL_DIR)
+	cp -rf ./.libs/gtest $(TEST_INSTALL_DIR)
+	cp -rf $(top_srcdir)/googletest/googletest/libgtest.so $(TEST_INSTALL_DIR)
+	$(TEST_INSTALL_DIR)/gtest
 
 clean-local:
 	${RM} test-procpidcgroup


### PR DESCRIPTION
Add support for installing testcases, so that the users can run it later
after installation too.  The installcheck hook is part of GNU automake
and under the hook, gtest binary gets build and copied over to
$(libdir)/libcgroup/tests/, along with its dependent library
googletest/libgtest.so.

Currently, the gtest is built/run with make check. While building it
uses -rpath to link with <libcgroup source>/googletest/../libgtest.so.
Just copying over the binary/library might fail to run, if the libcgroup
sources are removed, to address this issue an extra -rpath of install
the destination is pre-pended during linking.

Fixes: https://github.com/libcgroup/libcgroup/issues/60

Suggested-by: Ross Burton <ross.burton@arm.com>
Signed-off-by: Kamalesh Babulal <kamalesh.babulal@oracle.com>